### PR TITLE
CKEDITOR-228: Missing submit input for OfficeImporter form

### DIFF
--- a/ui/src/main/resources/CKEditor/OfficeImporter.xml
+++ b/ui/src/main/resources/CKEditor/OfficeImporter.xml
@@ -57,7 +57,7 @@
 {{/velocity}}
 
 {{velocity}}
-#if ("$!request.fileName" == '')
+#if ("$!request.fileName" == '' &amp;&amp; "$!xcontext.getAction()" == 'get')
   {{html clean="false"}}
   &lt;form class="xform"&gt;
     &lt;dl&gt;


### PR DESCRIPTION
## Issue

  https://jira.xwiki.org/browse/CKEDITOR-228

## Solution

* Only display OfficeImporter if action = get