### PR TITLE
CKEDITOR-268: Use the parameter display type for input rendering

### DIFF
--- a/ui/src/main/resources/CKEditor/MacroService.xml
+++ b/ui/src/main/resources/CKEditor/MacroService.xml
@@ -181,7 +181,7 @@
       'deprecated': $parameterDescriptor.deprecated,
       'advanced': $parameterDescriptor.advanced,
       'defaultValue': $parameterDescriptor.defaultValue,
-      'type': $parameterDescriptor.parameterType,
+      'type': $parameterDescriptor.displayType,
       'index': $foreach.index
     })
     #set ($groupDescriptor = $parameterDescriptor.groupDescriptor)


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/CKEDITOR-268

### Change

* Use the parameter display type instead of the actual type.