### PR TITLE
CKEDITOR-362: An hidden editor is taking focus and does not release a blur event before being destroyed

### DIFF
--- a/plugins/src/main/resources/xwiki-filter/plugin.js
+++ b/plugins/src/main/resources/xwiki-filter/plugin.js
@@ -84,6 +84,9 @@
       if (originalRange) {
         nativeSelection.addRange(originalRange);
       }
+      // Ensure to not have focus anymore on the editor so that keyboard shortcuts are available again
+      // (see CKEDITOR-362)
+      container.blur();
       // Destroy the test editor and check the produced HTML.
       editor.destroy();
       hasNonBreakingSpaceIssue = container.html().indexOf('a&nbsp;c') >= 0;


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/CKEDITOR-362

Fix: 
  * Call blur on the editor before destroying it.