### PR TITLE
CKEDITOR-207: Move to HTML5

### DIFF
--- a/application-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -57,8 +57,11 @@
   This is the sheet used to obtain the content that is passed to the [[CKEditor&gt;&gt;http://ckeditor.com/]].
 #else
   {{html clean="false"}}
-  ## We don't have a HTML5 parser yet so we use XHTML 1.0 header.
-  &lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"&gt;
+  #if ($services.wysiwyg.HTMLSyntax.version.startsWith("5"))
+    &lt;!DOCTYPE html&gt;
+  #else
+    &lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"&gt;
+  #end
   &lt;html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale" xml:lang="$xcontext.locale"&gt;
     &lt;head&gt;
       &lt;meta http-equiv="Content-Type" content="text/html; charset=$xwiki.encoding" /&gt;

--- a/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
@@ -295,6 +295,7 @@ define('xwiki-ckeditor', [
       // CKEditor uses '-' (dash) as locale separator (between the language code and the country code).
       language: currentLocale.toLowerCase().replace('_', '-'),
       uploadUrl: getUploadURL(sourceDocument, 'filetools'),
+      stylesSet: #if ($services.wysiwyg.HTMLSyntax.version.startsWith("5")) 'html5' #else 'html4' #end,
       'xwiki-link': {
         labelGenerator: sourceDocument.getURL('get', $.param({
           sheet: 'CKEditor.LinkLabelGenerator',

--- a/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
@@ -295,7 +295,7 @@ define('xwiki-ckeditor', [
       // CKEditor uses '-' (dash) as locale separator (between the language code and the country code).
       language: currentLocale.toLowerCase().replace('_', '-'),
       uploadUrl: getUploadURL(sourceDocument, 'filetools'),
-      stylesSet: #if ($services.wysiwyg.HTMLSyntax.version.startsWith("5")) 'html5' #else 'html4' #end,
+      stylesSet: $(element).data('syntax') === 'annotatedxhtml/1.0' ? 'html4' : 'html5',
       'xwiki-link': {
         labelGenerator: sourceDocument.getURL('get', $.param({
           sheet: 'CKEditor.LinkLabelGenerator',

--- a/application-ckeditor-ui/src/main/resources/CKEditor/InlineEditor.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/InlineEditor.xml
@@ -160,7 +160,8 @@
     container.attr({
       'data-sourceDocumentReference': XWiki.Model.serialize(config.document.documentReference),
       'data-sourceDocumentSyntax': config.document.syntax,
-      'data-officeImporterSupported': config.enableOfficeImport
+      'data-officeImporterSupported': config.enableOfficeImport,
+      'data-syntax': 'syntax' in config ? config['syntax'] : 'annotatedxhtml/1.0'
     }).each(function() {
       try {
         createEditor(ckeditor, this, config).done($.proxy(config.deferred, 'resolve', config.document));

--- a/application-ckeditor-ui/src/main/resources/CKEditor/LinkLabelGenerator.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/LinkLabelGenerator.xml
@@ -47,7 +47,7 @@
 #set ($syntax = $services.rendering.resolveSyntax('xwiki/2.1'))
 #set ($linkReference = $services.rendering.escape("$prefix$!request.reference", $syntax))
 #set ($xdom = $services.rendering.parse("[[$linkReference]]", $syntax.toIdString()))
-## We don't use the plain text renderer because it is not consistent with the XHTML renderer used in view mode.
-$services.rendering.render($xdom, 'xhtml/1.0')
+## We don't use the plain text renderer because it is not consistent with the HTML renderer used in view mode.
+$services.rendering.render($xdom, ${services.wysiwyg.HTMLSyntax.toIdString()|'xhtml/1.0'})
 {{/velocity}}</content>
 </xwikidoc>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/VelocityMacros.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/VelocityMacros.xml
@@ -217,7 +217,7 @@
   #set ($discard = $parameters.attributes.putAll({
     'class': "$!parameters.attributes.get('class') ckeditor-textarea loading",
     'spellcheck': false,
-    'data-syntax': 'annotatedxhtml/1.0',
+    'data-syntax': ${services.wysiwyg.HTMLSyntax.toIdString()|'annotatedxhtml/1.0'},
     'data-sourceDocumentSyntax': $sourceDocument.syntax.toIdString(),
     'data-officeImporterSupported': $officeImporterSupported
   }))

--- a/application-ckeditor-webjar/src/main/resources/styles.js
+++ b/application-ckeditor-webjar/src/main/resources/styles.js
@@ -26,43 +26,59 @@
 //
 // For more information refer to: http://docs.ckeditor.com/#!/guide/dev_styles-section-style-rules
 
-CKEDITOR.stylesSet.add('default', [
-  /* Block styles */
+[4, 5].forEach(htmlVersion => {
+    const styles = [
+        /* Block styles */
 
-  {name: 'Box', element: 'div', attributes: {'class': 'box'}},
-  {name: 'Info Box', element: 'div', attributes: {'class': 'box infomessage'}},
-  {name: 'Warning Box', element: 'div', attributes: {'class': 'box warningmessage'}},
-  {name: 'Success Box', element: 'div', attributes: {'class': 'box successmessage'}},
-  {name: 'Error Box', element: 'div', attributes: {'class': 'box errormessage'}},
-  {name: 'Floating Box', element: 'div', attributes: {'class': 'box floatinginfobox'}},
+        {name: 'Box', element: 'div', attributes: {'class': 'box'}},
+        {name: 'Info Box', element: 'div', attributes: {'class': 'box infomessage'}},
+        {name: 'Warning Box', element: 'div', attributes: {'class': 'box warningmessage'}},
+        {name: 'Success Box', element: 'div', attributes: {'class': 'box successmessage'}},
+        {name: 'Error Box', element: 'div', attributes: {'class': 'box errormessage'}},
+        {name: 'Floating Box', element: 'div', attributes: {'class': 'box floatinginfobox'}},
 
-  {name: 'Lead Paragraph', element: 'p', attributes: {'class': 'lead'}},
-  {name: 'Reverse Block Quote', element: 'blockquote', attributes: {'class': 'blockquote-reverse'}},
+        {name: 'Lead Paragraph', element: 'p', attributes: {'class': 'lead'}},
+        {name: 'Reverse Block Quote', element: 'blockquote', attributes: {'class': 'blockquote-reverse'}}
+    ];
 
-  /* Inline styles */
+    /* Inline styles */
 
-  {name: 'Typewriter', element: 'tt'},
-  {name: 'Marker', element: 'span', attributes: {'class': 'mark'}},
-  {name: 'Small', element: 'span', attributes: {'class': 'small'}},
-  {name: 'Uppercase', element: 'span', attributes: {'class': 'text-uppercase'}},  
+    if (htmlVersion === 4) {
+        styles.push({name: 'Typewriter', element: 'tt'});
+    } else {
+        styles.push({name: 'Typewriter', element: 'span', attributes: {'class': 'monospace'}});
+    }
 
-  /* Object styles */
+    styles.push(
+        {name: 'Marker', element: 'span', attributes: {'class': 'mark'}},
+        {name: 'Small', element: 'span', attributes: {'class': 'small'}},
+        {name: 'Uppercase', element: 'span', attributes: {'class': 'text-uppercase'}},
 
-  {name: 'Striped Table', element: 'table', attributes: {'class': 'table-striped'}},
-  {name: 'Bordered Table', element: 'table', attributes: {'class': 'table-bordered'}},
-  {name: 'Hover Table', element: 'table', attributes: {'class': 'table-hover'}},
-  {name: 'Condensed Table', element: 'table', attributes: {'class': 'table-condensed'}},
-  {name: 'Responsive Table', element: 'table', attributes: {'class': 'responsive-table'}},
+        /* Object styles */
 
-  {name: 'Active Row', element: 'tr', attributes: {'class': 'active'}},
-  {name: 'Success Row', element: 'tr', attributes: {'class': 'success'}},
-  {name: 'Info Row', element: 'tr', attributes: {'class': 'info'}},
-  {name: 'Warning Row', element: 'tr', attributes: {'class': 'warning'}},
-  {name: 'Danger Row', element: 'tr', attributes: {'class': 'danger'}},
+        {name: 'Striped Table', element: 'table', attributes: {'class': 'table-striped'}},
+        {name: 'Bordered Table', element: 'table', attributes: {'class': 'table-bordered'}},
+        {name: 'Hover Table', element: 'table', attributes: {'class': 'table-hover'}},
+        {name: 'Condensed Table', element: 'table', attributes: {'class': 'table-condensed'}},
+        {name: 'Responsive Table', element: 'table', attributes: {'class': 'responsive-table'}},
 
-  /* Widget styles */
+        {name: 'Active Row', element: 'tr', attributes: {'class': 'active'}},
+        {name: 'Success Row', element: 'tr', attributes: {'class': 'success'}},
+        {name: 'Info Row', element: 'tr', attributes: {'class': 'info'}},
+        {name: 'Warning Row', element: 'tr', attributes: {'class': 'warning'}},
+        {name: 'Danger Row', element: 'tr', attributes: {'class': 'danger'}},
 
-  {name: 'Rounded Image', type: 'widget', widget: 'image', element: 'img', attributes: {'class': 'img-rounded'}},
-  {name: 'Circle Image', type: 'widget', widget: 'image', element: 'img', attributes: {'class': 'img-circle'}},
-  {name: 'Thumbnail Image', type: 'widget', widget: 'image', element: 'img', attributes: {'class': 'img-thumbnail'}}
-]);
+        /* Widget styles */
+
+        {name: 'Rounded Image', type: 'widget', widget: 'image', element: 'img', attributes: {'class': 'img-rounded'}},
+        {name: 'Circle Image', type: 'widget', widget: 'image', element: 'img', attributes: {'class': 'img-circle'}},
+        {
+            name: 'Thumbnail Image',
+            type: 'widget',
+            widget: 'image',
+            element: 'img',
+            attributes: {'class': 'img-thumbnail'}
+        });
+
+    CKEDITOR.stylesSet.add('html' + htmlVersion, styles);
+});


### PR DESCRIPTION
* Switch CKEditor to use HTML5 depending on script service.
* Replace Typewriter style depending on HTML version.

Jira issue: https://jira.xwiki.org/browse/CKEDITOR-207

Note: this won't fix the behavior described in this issue as we just move to HTML 5 without allowing any additional elements. However, it does what the issue title says - move to HTML 5.

This depends on the script service API proposed in xwiki/xwiki-platform#1762
The changes are designed to be backwards-compatible, but if there should be any changes to the API this needs to be adapted.
