### PR TITLE
CKEDITOR-425: Submitting a macro form will add a comma to the parameters that bind pickers allowing multiple options

### DIFF
--- a/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
@@ -633,10 +633,12 @@ define(
       var value = data[parameter.name];
       if (value === undefined) {
         data[parameter.name] = parameter.value;
-      } else if (Array.isArray(value)) {
-        value.push(parameter.value);
-      } else {
-        data[parameter.name] = [value, parameter.value];
+      } else if (parameter.value !== '') {
+        if (Array.isArray(value)) {
+          value.push(parameter.value);
+        } else {
+          data[parameter.name] = [value, parameter.value];
+        }
       }
     });
     return data;


### PR DESCRIPTION
When transforming a macro form to a JS object, we need to skip empty strings when there are more than one values mapped from one given input name.