### PR TITLE
CKEDITOR-436: Introduce the new image dialog plugin

### DIFF
--- a/application-ckeditor-plugins/pom.xml
+++ b/application-ckeditor-plugins/pom.xml
@@ -156,6 +156,17 @@
                 <exclude>plugin.js</exclude>
               </excludes>
             </aggregation>
+            <!-- Aggregate the Image Dialog modules. -->
+            <aggregation>
+              <insertNewLine>true</insertNewLine>
+              <output>${webjar.contentDirectory}/xwiki-image/imageWizard.bundle.js</output>
+              <includes>
+                <include>*.js</include>
+              </includes>
+              <excludes>
+                <exclude>plugin.js</exclude>
+              </excludes>
+            </aggregation>
           </aggregations>
           <!-- We prefer to use the JSHint Maven Plugin because it gives us more control over the validation rules. -->
           <jswarn>false</jswarn>

--- a/application-ckeditor-plugins/src/main/resources/xwiki-dialog/modal.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-dialog/modal.js
@@ -94,18 +94,8 @@ define('modal', ['jquery', 'l10n!modal', 'bootstrap'], function($, translations)
     };
   };
 
-  return {
-    createModal: createModal,
-    createModalStep: createModalStep
-  };
-});
-
-/**
- * Utility module to load required skin extensions.
- */
-define('xwiki-skinx', ['jquery'], function($) {
-  'use strict';
-
+  // TODO: This method must be removed once the parent version is upgraded to  13.4.3+, 12.10.9+, or 13.7-rc-1+ 
+  // (see https://jira.xwiki.org/browse/XWIKI-18895)
   $.fn.loadRequiredSkinExtensions = function(requiredSkinExtensions) {
     return this.each(function() {
       // 'this' can be an element, the window or the document itself.
@@ -125,5 +115,10 @@ define('xwiki-skinx', ['jquery'], function($) {
         return existingSkinExtensions.indexOf(url) < 0;
       }).appendTo(head);
     });
+  };
+  
+  return {
+    createModal: createModal,
+    createModalStep: createModalStep
   };
 });

--- a/application-ckeditor-plugins/src/main/resources/xwiki-dialog/modal.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-dialog/modal.js
@@ -99,3 +99,31 @@ define('modal', ['jquery', 'l10n!modal', 'bootstrap'], function($, translations)
     createModalStep: createModalStep
   };
 });
+
+/**
+ * Utility module to load required skin extensions.
+ */
+define('xwiki-skinx', ['jquery'], function($) {
+  'use strict';
+
+  $.fn.loadRequiredSkinExtensions = function(requiredSkinExtensions) {
+    return this.each(function() {
+      // 'this' can be an element, the window or the document itself.
+      var ownerDocument = this.ownerDocument || this.document || this;
+      var head = $(ownerDocument).find('head');
+      var existingSkinExtensions;
+      var getExistingSkinExtensions = function() {
+        return head.find('link, script').map(function() {
+          return $(this).attr('href') || $(this).attr('src');
+        }).get();
+      };
+      $('<div></div>').html(requiredSkinExtensions).find('link, script').filter(function() {
+        if (!existingSkinExtensions) {
+          existingSkinExtensions = getExistingSkinExtensions();
+        }
+        var url = $(this).attr('href') || $(this).attr('src');
+        return existingSkinExtensions.indexOf(url) < 0;
+      }).appendTo(head);
+    });
+  };
+});

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image-old/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image-old/plugin.js
@@ -1,0 +1,240 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+(function() {
+  'use strict';
+
+  // Declare the configuration namespace.
+  CKEDITOR.config['xwiki-image'] = CKEDITOR.config['xwiki-image'] || {
+    __namespace: true
+  };
+
+  CKEDITOR.plugins.add('xwiki-image-old', {
+    requires: 'xwiki-marker,xwiki-resource,balloontoolbar',
+
+    beforeInit: function(editor) {
+      editor.on('widgetDefinition', function(event) {
+        var widgetDefinition = event.data;
+        if (widgetDefinition.name === "image" && widgetDefinition.dialog === "image2") {
+          this.overrideImageWidget(editor, widgetDefinition);
+        }
+      }, this);
+    },
+
+    init: function(editor) {
+      editor.plugins['xwiki-marker'].addMarkerHandler(editor, 'image', {
+        // startImageComment: CKEDITOR.htmlParser.comment
+        // content: CKEDITOR.htmlParser.node[]
+        toHtml: function(startImageComment, content) {
+          if (content.length === 1 && content[0].name === 'img') {
+            var image = content[0];
+            // Protect the image rendering markers by saving their data on the image element itself.
+            var reference = startImageComment.value.substring('startimage:'.length);
+            image.attributes['data-reference'] = CKEDITOR.tools.unescapeComment(reference);
+            // Handle free-standing images.
+            if (image.hasClass('wikimodel-freestanding')) {
+              image.attributes['data-freestanding'] = true;
+              // This is an internal class that should not be visible when editing the image.
+              image.removeClass('wikimodel-freestanding');
+              // The alt attribute is auto-generated for free-standing images. We remove it in order to be consistent
+              // with the wiki syntax where it's not specified.
+              delete image.attributes.alt;
+            }
+          } else {
+            // Unexpected HTML structure inside image markers. Keep the markers.
+            return false;
+          }
+        },
+        // element: CKEDITOR.htmlParser.element
+        isMarked: function(element) {
+          return element.name === 'img' && element.attributes['data-reference'];
+        },
+        // image: CKEDITOR.htmlParser.element
+        toDataFormat: function(image) {
+          // Put back the image rendering markers.
+          var reference = CKEDITOR.tools.escapeComment(image.attributes['data-reference']);
+          var startImageComment = new CKEDITOR.htmlParser.comment('startimage:' + reference);
+          var stopImageComment = new CKEDITOR.htmlParser.comment('stopimage');
+          startImageComment.insertBefore(image);
+          stopImageComment.insertAfter(image);
+          delete image.attributes['data-reference'];
+          // Handle free-standing images.
+          var freeStanding = image.attributes['data-freestanding'] === 'true';
+          delete image.attributes['data-freestanding'];
+          // Free-standing images don't have white-space in their reference and have only the src attribute set.
+          if (freeStanding && !/\s+/.test(reference) && isFreeStandingImage(image)) {
+            image.addClass('wikimodel-freestanding');
+          }
+        }
+      });
+
+      editor.balloonToolbars.create({
+        buttons: 'Link,Unlink,Image',
+        widgets: 'image'
+      });
+    },
+
+    overrideImageWidget: function(editor, imageWidget) {
+      var originalInit = imageWidget.init;
+      imageWidget.init = function() {
+        originalInit.call(this);
+        var serializedResourceReference = this.parts.image.getAttribute('data-reference');
+        if (serializedResourceReference) {
+          this.setData('resourceReference', CKEDITOR.plugins.xwikiResource
+            .parseResourceReference(serializedResourceReference));
+        }
+      };
+
+      var originalData = imageWidget.data;
+      imageWidget.data = function() {
+        var resourceReference = this.data.resourceReference;
+        if (resourceReference) {
+          this.parts.image.setAttribute('data-reference', CKEDITOR.plugins.xwikiResource
+            .serializeResourceReference(resourceReference));
+        }
+        originalData.call(this);
+      };
+
+      // Adds support for configuring the allowed content for image caption (currently hard-coded).
+      var captionAllowedContent = (editor.config['xwiki-image'] || {}).captionAllowedContent;
+      if (captionAllowedContent) {
+        imageWidget.editables.caption.allowedContent = captionAllowedContent;
+      }
+
+      //
+      // Don't remove the width/height if they are specified using percentage.
+      // See CKEDITOR-122: CKEditor removes image width when specified as percentage
+      //
+
+      // @param {CKEDITOR.htmlParser.element} image
+      // @param {String} dimension ('width' or 'height')
+      var maybeProtectDimension = function(image, dimension) {
+        var value = typeof image.attributes[dimension] === 'string' && image.attributes[dimension].trim();
+        if (value.length && value.charAt(value.length - 1) === '%') {
+          image[dimension + '%'] = image.attributes[dimension];
+          delete image.attributes[dimension];
+          return true;
+        }
+      };
+
+      // @param {CKEDITOR.htmlParser.element} image
+      // @param {String} dimension ('width' or 'height')
+      var maybeUnprotectDimension = function(image, dimension) {
+        if (image[dimension + '%']) {
+          image.attributes[dimension] = image[dimension + '%'];
+          delete image[dimension + '%'];
+        }
+      };
+
+      var originalUpcast = imageWidget.upcast;
+      // @param {CKEDITOR.htmlParser.element} element
+      // @param {Object} data
+      imageWidget.upcast = function(element, data) {
+        var imagesUsingPercent = [];
+        element.forEach(function(childElement) {
+          // Note that we're using the Bitwise OR (|) operator because we want to protect both attributes.
+          if (element.name === 'img' && (maybeProtectDimension(element, 'width') |
+            maybeProtectDimension(element, 'height'))) {
+            imagesUsingPercent.push(element);
+          }
+        }, CKEDITOR.NODE_ELEMENT);
+        try {
+          return originalUpcast.apply(this, arguments);
+        } finally {
+          imagesUsingPercent.forEach(function(image) {
+            maybeUnprotectDimension(image, 'width');
+            maybeUnprotectDimension(image, 'height');
+          });
+        }
+      };
+    }
+  });
+
+  CKEDITOR.on('dialogDefinition', function(event) {
+    // Make sure we affect only the editors that load this plugin.
+    if (!event.editor.plugins['xwiki-image-old']) {
+      return;
+    }
+
+    // Take the dialog window name and its definition from the event data.
+    var dialogName = event.data.name;
+    var dialogDefinition = event.data.definition;
+    if (dialogName === 'image2') {
+      replaceWithResourcePicker(dialogDefinition, 'src', {
+        resourceTypes: (event.editor.config['xwiki-image'] || {}).resourceTypes || ['attach', 'icon', 'url'],
+        setup: function(widget) {
+          this.setValue(widget.data.resourceReference);
+        },
+        commit: function(widget) {
+          var oldResourceReference = widget.data.resourceReference || {};
+          var newResourceReference = this.getValue();
+          if (oldResourceReference.type !== newResourceReference.type ||
+            oldResourceReference.reference !== newResourceReference.reference) {
+            newResourceReference.typed = newResourceReference.type !== 'attach' &&
+              (newResourceReference.type !== 'url' || newResourceReference.reference.indexOf('://') < 0);
+            widget.setData('resourceReference', CKEDITOR.tools.extend(newResourceReference, oldResourceReference));
+          }
+        }
+      });
+      CKEDITOR.plugins.xwikiResource.updateResourcePickerOnFileBrowserSelect(dialogDefinition,
+        ['info', 'resourceReference'], ['Upload', 'uploadButton']);
+
+      // See CKEDITOR-122: CKEditor removes image width when specified as percentage
+      allowRelativeDimensions(dialogDefinition);
+    }
+  });
+
+  var replaceWithResourcePicker = function(dialogDefinition, replacedElementId, pickerDefinition) {
+    var path = CKEDITOR.plugins.xwikiDialog.getUIElementPath(replacedElementId, dialogDefinition.contents);
+    if (path && path.length > 2) {
+      pickerDefinition = CKEDITOR.plugins.xwikiResource.createResourcePicker(pickerDefinition);
+      // Bind the replaced element to the resource picker (in order to commit the resource picker value).
+      var tabId = path[path.length - 1].element.id;
+      CKEDITOR.plugins.xwikiResource.bindResourcePicker(path[0].element, [tabId, pickerDefinition.id]);
+      // Hide the parent.
+      path[1].element.hidden = true;
+      // Insert the new element before the hidden parent.
+      path[2].element.children.splice(path[1].position, 0, pickerDefinition);
+    }
+  };
+
+  var allowRelativeDimensions = function(imageDialog) {
+    var infoTab = imageDialog.getContents('info');
+    allowRelativeDimension(infoTab, 'width');
+    allowRelativeDimension(infoTab, 'height');
+  };
+
+  var regexPercent = /^\s*(\d+\%)\s*$/i;
+  var allowRelativeDimension = function(infoTab, dimension) {
+    var originalValidate = infoTab.get(dimension).validate;
+    infoTab.get(dimension).validate = function() {
+      return this.getValue().match(regexPercent) || originalValidate.apply(this, arguments);
+    };
+  };
+
+  // Free-standing images have only the source attribute set.
+  var isFreeStandingImage = function(image) {
+    for (var attribute in image.attributes) {
+      if (image.attributes.hasOwnProperty(attribute) && attribute !== 'src' && image.attributes[attribute] !== '') {
+        return false;
+      }
+    }
+    return true;
+  };
+})();

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
@@ -22,21 +22,19 @@ define('imageEditorTranslationKeys', [], [
   'modal.backToEditor.button',
   'modal.loadFail.message',
   'modal.title',
-  'modal.insertButton'
+  'modal.insertButton',
+  'modal.initialization.fail'
 ]);
 
 define('imageStyleClient', ['jquery'], function($) {
   'use strict';
   var cachedResultDefault;
   var cachedResult;
-
-  var restURL = XWiki.contextPath + "/rest/wikis/" + XWiki.currentWiki + "/imageStyles";
-
   // Load the styles once and use a cached version if the styles are requested again.
   function loadImageStylesDefault() {
     if (cachedResultDefault === undefined) {
 
-      return Promise.resolve($.getJSON(restURL + "/default",
+      return Promise.resolve($.getJSON(XWiki.contextPath + $("#defaultImageStylesRestURL").val(),
         $.param({'documentReference': XWiki.Model.serialize(XWiki.currentDocument.documentReference)})))
         .then(function(defaultStyle) {
           cachedResultDefault = defaultStyle;
@@ -49,7 +47,7 @@ define('imageStyleClient', ['jquery'], function($) {
 
   function loadImageStyles() {
     if (cachedResult === undefined) {
-      return Promise.resolve($.getJSON(restURL,
+      return Promise.resolve($.getJSON(XWiki.contextPath + $("#imageStylesRestURL").val(),
         $.param({'documentReference': XWiki.Model.serialize(XWiki.currentDocument.documentReference)}))
         .then(function(defaultStyles) {
           cachedResult = defaultStyles;
@@ -151,7 +149,8 @@ define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor'
 
 
           }).fail(function(error) {
-          console.log('Failed to retrieve the image edition form.', error);
+            new XWiki.widgets.Notification(translations.get('modal.initialization.fail'), 'error');
+            console.log('Failed to retrieve the image edition form.', error);
         });
       } else {
         updateForm(modal);
@@ -220,7 +219,7 @@ define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor'
         modal.data('input').imageData = modal.data('input').imageData || {};
         modal.data('input').imageData.imageStyle = imageStyle;
 
-        var config = (imageStylesConfig || []).find(function(imageStyleConfig) {
+        var config = (imageStylesConfig.imageStyles || []).find(function(imageStyleConfig) {
           return imageStyleConfig.type === imageStyle;
         });
         var noStyle = false;
@@ -253,7 +252,7 @@ define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor'
       $('.image-editor a[href="#standard"]').tab('show');
 
       // Style
-      if (imageData.imageStyle) {
+      if (imageData.imageStyle || imageData.imageStyle === '') {
         $('#imageStyles')[0].selectize.setValue(imageData.imageStyle);
       }
 

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
@@ -87,7 +87,7 @@ define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor'
                     var imageStyles = values.imageStyles.map(function(value) {
                       return {
                         label: value.prettyName,
-                        value: value.identifier
+                        value: value.type
                       };
                     });
                     imageStyles.unshift({label: '---', value: ''});
@@ -190,7 +190,7 @@ define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor'
       var i = 0;
       for (i; i < imageStylesConfig.length; i++) {
         var imageStyleConfig = imageStylesConfig[i];
-        if (imageStyleConfig.identifier === imageStyle) {
+        if (imageStyleConfig.type === imageStyle) {
           return imageStyleConfig;
         }
       }

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
@@ -93,7 +93,7 @@ define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor'
                     imageStyles.unshift({label: '---', value: ''});
                     callback(imageStyles);
                     // Sets the default value once the values are loaded.
-                    imageStylesField.data('selectize').addItem(defaultStyle.defaultStyle);
+                    imageStylesField.data('selectize').addItem(defaultStyle.defaultStyle || '');
                     resolve(values.imageStyles);
                   }, function(err) {
                     reject(err);
@@ -247,6 +247,7 @@ define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor'
         if (config === undefined) {
           config = {};
           noStyle = true;
+          overrideValues = false;
         }
 
         // Image size

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
@@ -64,7 +64,7 @@ define('imageStyleClient', ['jquery'], function($) {
   };
 });
 
-define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor', 'xwiki-skinx'],
+define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor'],
   function($, $modal, imageStyleClient, translations) {
     'use strict';
 

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageEditor.js
@@ -1,0 +1,336 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+define('imageEditorTranslationKeys', [], [
+  'modal.backToEditor.button',
+  'modal.loadFail.message',
+  'modal.title',
+  'modal.insertButton'
+]);
+
+define('imageStyleClient', ['jquery'], function($) {
+  'use strict';
+  var cachedResultDefault;
+  var cachedResult;
+
+  var restURL = XWiki.contextPath + "/rest/wikis/" + XWiki.currentWiki + "/imageStyles";
+
+  // Load the styles once and use a cached version if the styles are requested again.
+  function loadImageStylesDefault() {
+    if (cachedResultDefault === undefined) {
+
+      return $.getJSON(restURL + "/default",
+        $.param({'documentReference': XWiki.Model.serialize(XWiki.currentDocument.documentReference)}))
+        .then(function(defaultStyle) {
+          cachedResultDefault = defaultStyle;
+          return defaultStyle;
+        });
+    } else {
+      return Promise.resolve(cachedResultDefault);
+    }
+  }
+
+  function loadImageStyles() {
+    if (cachedResult === undefined) {
+      return $.getJSON(restURL,
+        $.param({'documentReference': XWiki.Model.serialize(XWiki.currentDocument.documentReference)}))
+        .then(function(defaultStyles) {
+          cachedResult = defaultStyles;
+          return defaultStyles;
+        });
+    } else {
+      return Promise.resolve(cachedResult);
+    }
+  }
+
+  return {
+    loadImageStyles: loadImageStyles,
+    loadImageStylesDefault: loadImageStylesDefault
+  };
+});
+
+// TODO: xwiki-skinx is a macro selector specific module, it needs to be moved somewhere common.
+define('imageEditor', ['jquery', 'modal', 'imageStyleClient', 'l10n!imageEditor', 'xwiki-skinx'],
+  function($, $modal, imageStyleClient, translations) {
+    'use strict';
+
+    function initImageStyleField(modal) {
+      return new Promise(function(resolve, reject) {
+        var imageStylesField = $('#imageStyles');
+        if (imageStylesField) {
+          imageStyleClient.loadImageStylesDefault()
+            .then(function(defaultStyle) {
+              var settings = {
+                preload: true,
+                onChange: function(value) {
+                  updateAdvancedFromStyle(value, modal);
+                },
+                load: function(typedText, callback) {
+                  imageStyleClient.loadImageStyles().then(function(values) {
+                    var imageStyles = values.imageStyles.map(function(value) {
+                      return {
+                        label: value.prettyName,
+                        value: value.identifier
+                      };
+                    });
+                    imageStyles.unshift({label: '---', value: ''});
+                    callback(imageStyles);
+                    // Sets the default value once the values are loaded.
+                    imageStylesField.data('selectize').addItem(defaultStyle.defaultStyle);
+                    resolve(values.imageStyles);
+                  }, function(err) {
+                    reject(err);
+                  });
+                }
+              };
+
+              imageStylesField.xwikiSelectize(settings);
+            }, function(err) {
+              reject(err);
+            });
+        } else {
+          resolve();
+        }
+      });
+    }
+
+    // TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
+    function initCaptionField() {
+      var activation = $('#imageCaptionActivation');
+      if (activation) {
+        activation.change(function() {
+          $("#imageCaption").prop('disabled', !this.checked);
+        });
+      }
+    }
+
+    function addChangeImageButton(insertButton, modal) {
+      var selectImageButton = $('<button type="button" class="btn btn-default pull-left"></button>')
+        .text(translations.get('modal.backToEditor.button'))
+        .prependTo(insertButton.parent());
+      selectImageButton.on('click', function() {
+        var macroData = getFormData(modal);
+        modal.data('output', {
+          action: 'selectImage',
+          editor: modal.data('input').editor,
+          macroData: macroData
+        }).modal('hide');
+      });
+    }
+
+    // Fetch modal content from a remote template the first time the image dialog editor is opened.
+    function initialize(modal) {
+      var params = modal.data('input');
+      if (!modal.data('initialized')) {
+        var url = new XWiki.Document(XWiki.Model.resolve('CKEditor.ImageEditorService', XWiki.EntityType.DOCUMENT))
+          .getURL('get');
+        $.get(url, $.param({
+          language: $('html').attr('lang'),
+          isHTML5: $(params.editor.document).data('syntax') !== 'annotatedxhtml/1.0'
+        }))
+          .done(function(html, textState, jqXHR) {
+            var imageEditor = $('.image-editor');
+            var requiredSkinExtensions = jqXHR.getResponseHeader('X-XWIKI-HTML-HEAD');
+            $(params.editor.document.$).loadRequiredSkinExtensions(requiredSkinExtensions);
+            imageEditor.html(html);
+            // TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
+            // initCaptionField();
+            initImageStyleField(modal).then(function() {
+              imageEditor.removeClass('loading');
+              $('.image-editor-modal button.btn-primary').prop('disabled', false);
+              updateForm(modal);
+              modal.data('initialized', true);
+            });
+
+
+          }).fail(function(error) {
+          console.log('Failed to retrieve the image edition form.', error);
+        });
+      } else {
+        updateForm(modal);
+      }
+    }
+
+    function getFormData(modal) {
+      var resourceReference = modal.data('input').macroData.resourceReference;
+      return {
+        resourceReference: resourceReference,
+        imageStyle: $('#imageStyles').val(),
+        alignment: $('#advanced [name="alignment"]:checked').val(),
+        border: $('#advanced [name="imageBorder"]').is(':checked'),
+        textWrap: $('#advanced [name="textWrap"]').is(':checked'),
+        alt: $('#altText').val(),
+        hasCaption: $("#imageCaptionActivation").is(':checked'),
+        // TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
+        //imageCaption: $("#imageCaption").val(), 
+        width: $("#imageWidth").val(),
+        height: $("#imageHeight").val(),
+        src: CKEDITOR.plugins.xwikiResource.getResourceURL(resourceReference, modal.data('input').editor)
+      };
+    }
+
+    function filterImageStyles(imageStylesConfig, imageStyle) {
+      var i = 0;
+      for (i; i < imageStylesConfig.length; i++) {
+        var imageStyleConfig = imageStylesConfig[i];
+        if (imageStyleConfig.identifier === imageStyle) {
+          return imageStyleConfig;
+        }
+      }
+      return undefined;
+    }
+
+    function updateAdvancedFromStyle(imageStyle, modal) {
+      function updateImageSize(config, noStyle, overrideValues) {
+        var adjustableSize = config.adjustableSize !== false;
+        var imageWidth = $('#imageWidth');
+        var imageHeight = $('#imageHeight');
+        imageWidth.prop("disabled", !adjustableSize && !noStyle);
+        imageHeight.prop("disabled", !adjustableSize && !noStyle);
+        if (overrideValues) {
+          imageWidth.val(config.defaultWidth);
+          imageHeight.val(config.defaultHeight);
+        }
+      }
+
+      function updateBorder(config, noStyle, overrideValues) {
+        var imageBorder = $('#imageBorder');
+        imageBorder.prop('disabled', !config.adjustableBorder && !noStyle);
+        if (overrideValues) {
+          imageBorder.prop('checked', config.defaultBorder);
+        }
+      }
+
+      function updateAlignment(config, noStyle, overrideValues) {
+        var alignment = $('#advanced [name="alignment"]');
+        alignment.prop('disabled', !config.adjustableAlignment && !noStyle);
+        if (overrideValues) {
+          alignment.val([config.defaultAlignment || 'none']);
+        }
+      }
+
+      function updateTextWrap(config, noStyle, overrideValues) {
+        var textWrap = $('#advanced [name="textWrap"]');
+        textWrap.prop('disabled', !config.adjustableTextWrap && !noStyle);
+        if (overrideValues) {
+          textWrap.prop('checked', config.defaultTextWrap);
+        }
+      }
+
+      imageStyleClient.loadImageStyles().then(function(imageStylesConfig) {
+        // Do not update the form if the current style is the same are the one of the current user.
+        var overrideValues = modal.data('input').macroData === undefined ||
+          modal.data('input').macroData.imageStyle !== imageStyle;
+
+        modal.data('input').macroData = modal.data('input').macroData || {};
+        modal.data('input').macroData.imageStyle = imageStyle;
+
+        var config = filterImageStyles(imageStylesConfig.imageStyles, imageStyle);
+        var noStyle = false;
+        if (config === undefined) {
+          config = {};
+          noStyle = true;
+        }
+
+        // Image size
+        updateImageSize(config, noStyle, overrideValues);
+
+        // Border
+        updateBorder(config, noStyle, overrideValues);
+
+        // Alignment
+        updateAlignment(config, noStyle, overrideValues);
+
+        // Text Wrap
+        updateTextWrap(config, noStyle, overrideValues);
+      });
+    }
+
+    // Update the form according to the modal input data.
+    // 
+    function updateForm(modal) {
+      var macroData = modal.data('input').macroData || {};
+
+      // Switch back to the default tab
+      $('.image-editor a[href="#standard"]').tab('show');
+
+      // Style
+      if (macroData.imageStyle) {
+        $('#imageStyles')[0].selectize.setValue(macroData.imageStyle);
+      }
+
+      // Alt
+      $('#altText').val(macroData.alt);
+
+
+      // Caption
+      $('#imageCaptionActivation').prop('checked', macroData.hasCaption);
+      // TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
+      /*
+      var imageCaption = $('#imageCaption');
+      if (macroData.hasCaption) {
+        imageCaption.val(macroData.imageCaption);
+        imageCaption.prop('disabled', false);
+      } else {
+        imageCaption.val('');
+        imageCaption.prop('disabled', true);
+      }
+      */
+
+      // Image size
+      $('#imageWidth').val(macroData.width);
+      $('#imageHeight').val(macroData.height);
+
+      // Border
+      $('#imageBorder').prop('checked', macroData.border);
+
+      // Alignment
+      $('#advanced [name="alignment"]').val([macroData.alignment]);
+
+      // Text Wrap
+      $('#advanced [name="textWrap"]').prop('checked', macroData.textWrap);
+
+      // Override with the style values only of it's an new image
+      updateAdvancedFromStyle($('#imageStyles')[0].selectize.getValue(), modal);
+    }
+
+    return $modal.createModalStep({
+      'class': 'image-editor-modal',
+      title: translations.get('modal.title'),
+      acceptLabel: translations.get('modal.insertButton'),
+      content: '<div class="image-editor loading"></div>',
+      onLoad: function() {
+        var modal = this;
+        var insertButton = modal.find('.modal-footer .btn-primary');
+        // Make the modal larger.
+        modal.find('.modal-dialog').addClass('modal-lg');
+
+        modal.on('shown.bs.modal', function() {
+          initialize(modal);
+        });
+        insertButton.on('click', function() {
+          var output = getFormData(modal);
+          modal.data('output', output).modal('hide');
+        });
+
+        addChangeImageButton(insertButton, modal);
+      }
+    });
+  });

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
@@ -20,12 +20,16 @@
 define('imageSelectorTranslationKeys', [], [
   'modal.title',
   'modal.loadFail.message',
-  'modal.selectButton'
+  'modal.selectButton',
+  'modal.fileUpload.success',
+  'modal.fileUpload.fail',
+  'modal.fileUpload.abort',
+  'modal.initialization.fail'
 ]);
 
 
-define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l10n!imageSelector', 'xwiki-skinx'],
-  function($, $modal, resource, notification, translations) {
+define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector', 'xwiki-skinx'],
+  function($, $modal, resource, translations) {
     'use strict';
 
     function getSelected(instance) {
@@ -64,19 +68,19 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l1
           var serialized = XWiki.Model.serialize(entityReference);
           saveSelectedImageReference(serialized, modal);
           imageSelector.removeClass('loading');
-          notification('File upload succeeded', $("#upload > form > dl > dd"), 'done');
+          new XWiki.widgets.Notification(translations.get('modal.fileUpload.success'), 'done');
         });
 
         // Return non-false value will disable fileButton in dialogui,
         // below listeners takes care of such situation and re-enable "send" button.
         loader.on('error', function(error) {
           console.log('Failed to upload a file', error);
-          notification('File upload failed', $("#upload > form > dl > dd"), 'error');
+          new XWiki.widgets.Notification(translations.get('modal.fileUpload.fail'), 'error');
           imageSelector.removeClass('loading');
         });
         loader.on('abort', function(error) {
           console.log('Failed to upload a file', error);
-          notification('File upload aborder', $("#upload > form > dl > dd"), 'error');
+          new XWiki.widgets.Notification(translations.get('modal.fileUpload.abort'), 'error');
           imageSelector.removeClass('loading');
         });
 
@@ -127,6 +131,7 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l1
             modal.data('initialized', true);
           }).fail(function(error) {
           console.log('Failed to retrieve the image selection form.', error);
+          new XWiki.widgets.Notification(translations.get('modal.initialization.fail'), 'error');
           modal.data('initialized', true);
         });
       }

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
@@ -25,7 +25,7 @@ define('imageSelectorTranslationKeys', [], [
 
 
 // TODO: xwiki-skinx is a macro selector specific module, it needs to be moved somewhere common.
-define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l10n!imageEditor', 'xwiki-skinx'],
+define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l10n!imageSelector', 'xwiki-skinx'],
   function($, $modal, resource, notification, translations) {
     'use strict';
 
@@ -64,7 +64,6 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l1
           var entityReference = resource.convertResourceReferenceToEntityReference(resourceReference);
           var serialized = XWiki.Model.serialize(entityReference);
           saveSelectedImageReference(serialized, modal);
-          // TODO: show success and stop spinner and cleanup upload field.
           imageSelector.removeClass('loading');
           notification('File upload succeeded', $("#upload > form > dl > dd"), 'done');
         });
@@ -87,7 +86,15 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l1
       });
     }
 
-    function getEntityReference(reference) {
+    function getEntityReference(referenceStr) {
+      var reference;
+      if (referenceStr.startsWith("attachment:")) {
+        var separatorIndex = referenceStr.indexOf(':');
+        reference = referenceStr.substr(separatorIndex + 1);
+      } else {
+        reference = referenceStr;
+      }
+
       return XWiki.Model.resolve(reference, XWiki.EntityType.ATTACHMENT);
     }
 

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
@@ -127,12 +127,6 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l1
     }
 
     // Initialize the modal.
-    /**
-     * TODO:
-     * - Provide an API to pass on the selected image to the next step.
-     */
-
-    // TOOD: Use a data property to know if the content has been loaded, that way the content is only loaded once.
     return $modal.createModalStep({
       'class': 'image-selector-modal',
       title: translations.get('modal.title'),
@@ -143,12 +137,7 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l1
         var selectButton = modal.find('.modal-footer .btn-primary');
         // Make the modal larger.
         modal.find('.modal-dialog').addClass('modal-lg');
-
-        // TODO: template:
-        // See https://getbootstrap.com/docs/4.2/components/navs/#tabs for the tabs (one per selector)
-        // Then a https://getbootstrap.com/docs/4.2/components/forms/ for each tab
-        // Same for the pane (one default tab + 1 advanced one (or an expandable field as we do for the macros?)
-
+        
         modal.on('shown.bs.modal', function() {
           initialize(modal);
         });

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
@@ -28,7 +28,7 @@ define('imageSelectorTranslationKeys', [], [
 ]);
 
 
-define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector', 'xwiki-skinx'],
+define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector'],
   function($, $modal, resource, translations) {
     'use strict';
 

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
@@ -1,0 +1,170 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+define('imageSelectorTranslationKeys', [], [
+  'modal.title',
+  'modal.loadFail.message',
+  'modal.selectButton'
+]);
+
+
+// TODO: xwiki-skinx is a macro selector specific module, it needs to be moved somewhere common.
+define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l10n!imageEditor', 'xwiki-skinx'],
+  function($, $modal, resource, notification, translations) {
+    'use strict';
+
+    function getSelected(instance) {
+      /* jshint camelcase: false */
+      return instance.get_selected(false)[0];
+    }
+
+    function validateSelection(instance) {
+      var selected = getSelected(instance);
+      return selected && selected.startsWith("attachment:");
+    }
+
+    // TODO: should be loaded modularily and provided by the UIX for the image selector tab.
+    function initDocumentTree(modal) {
+      $('.attachments-tree').xtree()
+        .one('ready.jstree', function(event, data) {
+          data.instance.openTo("document:" + XWiki.Model.serialize(XWiki.currentDocument.getDocumentReference()));
+        })
+        .on('changed.jstree', function(event, data) {
+          if (validateSelection(data.instance)) {
+            saveSelectedImageReference(getSelected(data.instance), modal);
+          } else {
+            removeSelectedImageReference(modal);
+          }
+        });
+    }
+
+    function initDocumentUpload(editor, modal) {
+      $("#upload form input.button").click(function(event) {
+        event.preventDefault();
+        var loader = editor.uploadRepository.create($("#fileUploadField").prop('files')[0]);
+        var imageSelector = $('.image-selector');
+        loader.on('uploaded', function(evt) {
+          var resourceReference = evt.sender.responseData.message.resourceReference;
+          var entityReference = resource.convertResourceReferenceToEntityReference(resourceReference);
+          var serialized = XWiki.Model.serialize(entityReference);
+          saveSelectedImageReference(serialized, modal);
+          // TODO: show success and stop spinner and cleanup upload field.
+          imageSelector.removeClass('loading');
+          notification('File upload succeeded', $("#upload > form > dl > dd"), 'done');
+        });
+
+        // Return non-false value will disable fileButton in dialogui,
+        // below listeners takes care of such situation and re-enable "send" button.
+        loader.on('error', function(error) {
+          console.log('Failed to upload a file', error);
+          notification('File upload failed', $("#upload > form > dl > dd"), 'error');
+          imageSelector.removeClass('loading');
+        });
+        loader.on('abort', function(error) {
+          console.log('Failed to upload a file', error);
+          notification('File upload aborder', $("#upload > form > dl > dd"), 'error');
+          imageSelector.removeClass('loading');
+        });
+
+        imageSelector.addClass('loading');
+        loader.loadAndUpload(editor.config.filebrowserUploadUrl);
+      });
+    }
+
+    function getEntityReference(reference) {
+      return XWiki.Model.resolve(reference, XWiki.EntityType.ATTACHMENT);
+    }
+
+    function saveSelectedImageReference(imageReference, modal) {
+      modal.data('imageReference', {
+        value: resource.convertEntityReferenceToResourceReference(getEntityReference(imageReference))
+      });
+      $('.image-selector-modal button.btn-primary').prop('disabled', false);
+    }
+
+    function removeSelectedImageReference(modal) {
+      modal.data('imageReference', {});
+      $('.image-selector-modal button.btn-primary').prop('disabled', true);
+    }
+
+    function initialize(modal) {
+      var params = modal.data('input');
+
+      if (!modal.data('initialized')) {
+        var url = new XWiki.Document(XWiki.Model.resolve('CKEditor.ImageSelectorService', XWiki.EntityType.DOCUMENT))
+          .getURL('get');
+        $.get(url, $.param({language: $('html').attr('lang')}))
+          .done(function(html, textState, jqXHR) {
+            var imageSelector = $('.image-selector');
+            var requiredSkinExtensions = jqXHR.getResponseHeader('X-XWIKI-HTML-HEAD');
+            $(params.editor.document.$).loadRequiredSkinExtensions(requiredSkinExtensions);
+            imageSelector.html(html);
+            imageSelector.removeClass('loading');
+            initDocumentTree(modal);
+            initDocumentUpload(params.editor, modal);
+            modal.data('initialized', true);
+          }).fail(function(error) {
+          console.log('Failed to retrieve the image selection form.', error);
+          modal.data('initialized', true);
+        });
+      }
+    }
+
+    // Initialize the modal.
+    /**
+     * TODO:
+     * - Provide an API to pass on the selected image to the next step.
+     */
+
+    // TOOD: Use a data property to know if the content has been loaded, that way the content is only loaded once.
+    return $modal.createModalStep({
+      'class': 'image-selector-modal',
+      title: translations.get('modal.title'),
+      acceptLabel: translations.get('modal.selectButton'),
+      content: '<div class="image-selector loading"></div>',
+      onLoad: function() {
+        var modal = this;
+        var selectButton = modal.find('.modal-footer .btn-primary');
+        // Make the modal larger.
+        modal.find('.modal-dialog').addClass('modal-lg');
+
+        // TODO: template:
+        // See https://getbootstrap.com/docs/4.2/components/navs/#tabs for the tabs (one per selector)
+        // Then a https://getbootstrap.com/docs/4.2/components/forms/ for each tab
+        // Same for the pane (one default tab + 1 advanced one (or an expandable field as we do for the macros?)
+
+        modal.on('shown.bs.modal', function() {
+          initialize(modal);
+        });
+        selectButton.on('click', function() {
+          var macroData = modal.data('input').macroData || {};
+          macroData.resourceReference = modal.data('imageReference').value;
+          if (macroData.resourceReference) {
+            macroData.resourceReference.typed = false;
+          }
+          var output = {
+            macroData: macroData,
+            editor: modal.data('input').editor,
+            newImage: modal.data('input').newImage
+          };
+          modal.data('output', output).modal('hide');
+        });
+      }
+    });
+  });

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
@@ -24,7 +24,6 @@ define('imageSelectorTranslationKeys', [], [
 ]);
 
 
-// TODO: xwiki-skinx is a macro selector specific module, it needs to be moved somewhere common.
 define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l10n!imageSelector', 'xwiki-skinx'],
   function($, $modal, resource, notification, translations) {
     'use strict';
@@ -55,7 +54,7 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l1
     }
 
     function initDocumentUpload(editor, modal) {
-      $("#upload form input.button").click(function(event) {
+      $("#upload form input.button").on('click', function(event) {
         event.preventDefault();
         var loader = editor.uploadRepository.create($("#fileUploadField").prop('files')[0]);
         var imageSelector = $('.image-selector');
@@ -120,7 +119,7 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l1
           .done(function(html, textState, jqXHR) {
             var imageSelector = $('.image-selector');
             var requiredSkinExtensions = jqXHR.getResponseHeader('X-XWIKI-HTML-HEAD');
-            $(params.editor.document.$).loadRequiredSkinExtensions(requiredSkinExtensions);
+            $(document).loadRequiredSkinExtensions(requiredSkinExtensions);
             imageSelector.html(html);
             imageSelector.removeClass('loading');
             initDocumentTree(modal);
@@ -149,13 +148,13 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'imageNotification', 'l1
           initialize(modal);
         });
         selectButton.on('click', function() {
-          var macroData = modal.data('input').macroData || {};
-          macroData.resourceReference = modal.data('imageReference').value;
-          if (macroData.resourceReference) {
-            macroData.resourceReference.typed = false;
+          var imageData = modal.data('input').imageData || {};
+          imageData.resourceReference = modal.data('imageReference').value;
+          if (imageData.resourceReference) {
+            imageData.resourceReference.typed = false;
           }
           var output = {
-            macroData: macroData,
+            imageData: imageData,
             editor: modal.data('input').editor,
             newImage: modal.data('input').newImage
           };

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageWizard.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageWizard.js
@@ -17,34 +17,6 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-/**
- * Utility module to load required skin extensions.
- * FIXME: duplicated from xwiki-macro.
- */
-define('xwiki-skinx', ['jquery'], function($) {
-  'use strict';
-  
-  $.fn.loadRequiredSkinExtensions = function(requiredSkinExtensions) {
-    return this.each(function() {
-      // 'this' can be an element, the window or the document itself.
-      var ownerDocument = this.ownerDocument || this.document || this;
-      var head = $(ownerDocument).find('head');
-      var existingSkinExtensions;
-      var getExistingSkinExtensions = function() {
-        return head.find('link, script').map(function() {
-          return $(this).attr('href') || $(this).attr('src');
-        }).get();
-      };
-      $('<div></div>').html(requiredSkinExtensions).find('link, script').filter(function() {
-        if (!existingSkinExtensions) {
-          existingSkinExtensions = getExistingSkinExtensions();
-        }
-        var url = $(this).attr('href') || $(this).attr('src');
-        return existingSkinExtensions.indexOf(url) < 0;
-      }).appendTo(head);
-    });
-  };
-});
 
 /**
  * Append a message to the specified location. Remove the message after a delay.
@@ -92,7 +64,7 @@ define('imageWizard', ['imageSelector', 'imageEditor'], function(imageSelector, 
   }
 
   return function(params) {
-    if (params.macroData && params.macroData.resourceReference) {
+    if (params.imageData && params.imageData.resourceReference) {
       return editOnly(params);
     } else {
       return selectAndEdit(params);

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageWizard.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageWizard.js
@@ -18,27 +18,6 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-/**
- * Append a message to the specified location. Remove the message after a delay.
- */
-define('imageNotification', ['jquery'], function($) {
-  'use strict';
-
-  return function(message, location, type) {
-    var delay = 5000;
-    if (type === 'error') {
-      delay = 10000;
-    }
-    var content = $("<div class='xnotification-wrapper'/>")
-      .append($("<div class='xnotification xnotification-" + type + "'/>")
-        .append(message));
-    location.append(content).delay(delay).queue(function() {
-      content.replaceWith('');
-    });
-  };
-});
-
-
 define('imageWizard', ['imageSelector', 'imageEditor'], function(imageSelector, imageEditor) {
   'use strict';
 

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageWizard.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageWizard.js
@@ -1,0 +1,101 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+/**
+ * Utility module to load required skin extensions.
+ * FIXME: duplicated from xwiki-macro.
+ */
+define('xwiki-skinx', ['jquery'], function($) {
+  'use strict';
+  
+  $.fn.loadRequiredSkinExtensions = function(requiredSkinExtensions) {
+    return this.each(function() {
+      // 'this' can be an element, the window or the document itself.
+      var ownerDocument = this.ownerDocument || this.document || this;
+      var head = $(ownerDocument).find('head');
+      var existingSkinExtensions;
+      var getExistingSkinExtensions = function() {
+        return head.find('link, script').map(function() {
+          return $(this).attr('href') || $(this).attr('src');
+        }).get();
+      };
+      $('<div></div>').html(requiredSkinExtensions).find('link, script').filter(function() {
+        if (!existingSkinExtensions) {
+          existingSkinExtensions = getExistingSkinExtensions();
+        }
+        var url = $(this).attr('href') || $(this).attr('src');
+        return existingSkinExtensions.indexOf(url) < 0;
+      }).appendTo(head);
+    });
+  };
+});
+
+/**
+ * Append a message to the specified location. Remove the message after a delay.
+ */
+define('imageNotification', ['jquery'], function($) {
+  'use strict';
+
+  return function(message, location, type) {
+    var delay = 5000;
+    if (type === 'error') {
+      delay = 10000;
+    }
+    var content = $("<div class='xnotification-wrapper'/>")
+      .append($("<div class='xnotification xnotification-" + type + "'/>")
+        .append(message));
+    location.append(content).delay(delay).queue(function() {
+      content.replaceWith('');
+    });
+  };
+});
+
+
+define('imageWizard', ['imageSelector', 'imageEditor'], function(imageSelector, imageEditor) {
+  'use strict';
+
+  function backToSelectionOrFinish(data) {
+    if (data.action === 'selectImage') {
+      return selectAndEdit(data);
+    } else {
+      return data;
+    }
+  }
+
+  function editOnly(params) {
+    return imageEditor(params)
+      .then(backToSelectionOrFinish);
+  }
+
+  function selectAndEdit(params) {
+    params = params || {};
+    params.newImage = true;
+    return imageSelector(params)
+      .then(imageEditor)
+      .then(backToSelectionOrFinish);
+  }
+
+  return function(params) {
+    if (params.macroData && params.macroData.resourceReference) {
+      return editOnly(params);
+    } else {
+      return selectAndEdit(params);
+    }
+  };
+});

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
@@ -86,7 +86,7 @@
 
         this.setData('border', this.parts.image.getAttribute('data-ckeditor-image-style-border'));
         this.setData('alignment', this.parts.image.getAttribute('data-ckeditor-image-style-alignment') || 'none');
-        this.setData('textWrap', this.parts.image.getAttribute('data-ckeditor-image-style-textWrap'));
+        this.setData('textWrap', this.parts.image.getAttribute('data-ckeditor-image-style-text-wrap'));
       };
 
       var originalData = imageWidget.data;
@@ -120,9 +120,9 @@
         }
 
         if (this.data.textWrap) {
-          this.parts.image.setAttribute('data-ckeditor-image-style-textWrap', this.data.textWrap);
+          this.parts.image.setAttribute('data-ckeditor-image-style-text-wrap', this.data.textWrap);
         } else {
-          this.parts.image.removeAttribute('data-ckeditor-image-style-textWrap');
+          this.parts.image.removeAttribute('data-ckeditor-image-style-text-wrap');
         }
 
         originalData.call(this);

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
@@ -24,7 +24,7 @@
     require(['imageWizard'], function(imageWizard) {
       imageWizard({
         editor: editor,
-        macroData: widget.data
+        imageData: widget.data
       }).done(function(data) {
         if (widget && widget.element) {
           widget.setData(data);
@@ -36,10 +36,10 @@
           // Append wrapper to a temporary document. This will unify the environment in which #data listeners work when
           // creating and editing widget.
           temp.append(wrapper);
-
-          var instance = editor.widgets.initOn(element, widget, {});
-          instance.setData(data);
-          editor.widgets.initOn(element, widget, data);
+          
+          // Initialize an empty image widget, then update it with the data from the image dialog.
+          var widgetInstance = editor.widgets.initOn(element, widget, {});
+          widgetInstance.setData(data);
           editor.widgets.finalizeCreation(temp);
         }
       });
@@ -47,7 +47,7 @@
   }
 
   CKEDITOR.plugins.add('xwiki-image', {
-    requires: 'xwiki-image-old', // TODO: maybe require modal to have skinx?
+    requires: 'xwiki-image-old,xwiki-dialog',
     init: function(editor) {
       this.initImageDialogWidget(editor);
     },
@@ -76,7 +76,6 @@
         if (this.parts.caption) {
           this.setData('hasCaption', true);
           // TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
-          //this.setData('imageCaption', this.parts.caption.getText())
         } else {
           this.setData('hasCaption', false);
         }
@@ -92,13 +91,8 @@
       var originalData = imageWidget.data;
       imageWidget.data = function() {
 
-
         // Caption
         // TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
-        /*if(this.data.hasCaption && this.parts.caption) {
-          
-           //this.parts.caption.setHtml('<p>'+this.data.imageCaption+'</p>');
-        }*/
 
         // Style
         if (this.data.imageStyle) {

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
@@ -82,11 +82,11 @@
         }
 
         // Style
-        this.setData('imageStyle', this.parts.image.getAttribute('data-ckeditor-image-style'));
+        this.setData('imageStyle', this.parts.image.getAttribute('data-xwiki-image-style'));
 
-        this.setData('border', this.parts.image.getAttribute('data-ckeditor-image-style-border'));
-        this.setData('alignment', this.parts.image.getAttribute('data-ckeditor-image-style-alignment') || 'none');
-        this.setData('textWrap', this.parts.image.getAttribute('data-ckeditor-image-style-text-wrap'));
+        this.setData('border', this.parts.image.getAttribute('data-xwiki-image-style-border'));
+        this.setData('alignment', this.parts.image.getAttribute('data-xwiki-image-style-alignment') || 'none');
+        this.setData('textWrap', this.parts.image.getAttribute('data-xwiki-image-style-text-wrap'));
       };
 
       var originalData = imageWidget.data;
@@ -102,27 +102,27 @@
 
         // Style
         if (this.data.imageStyle) {
-          this.parts.image.setAttribute('data-ckeditor-image-style', this.data.imageStyle);
+          this.parts.image.setAttribute('data-xwiki-image-style', this.data.imageStyle);
         } else {
-          this.parts.image.removeAttribute('data-ckeditor-image-style');
+          this.parts.image.removeAttribute('data-xwiki-image-style');
         }
 
         if (this.data.border) {
-          this.parts.image.setAttribute('data-ckeditor-image-style-border', this.data.border);
+          this.parts.image.setAttribute('data-xwiki-image-style-border', this.data.border);
         } else {
-          this.parts.image.removeAttribute('data-ckeditor-image-style-border');
+          this.parts.image.removeAttribute('data-xwiki-image-style-border');
         }
 
         if (this.data.alignment && this.data.alignment !== 'none') {
-          this.parts.image.setAttribute('data-ckeditor-image-style-alignment', this.data.alignment);
+          this.parts.image.setAttribute('data-xwiki-image-style-alignment', this.data.alignment);
         } else {
-          this.parts.image.removeAttribute('data-ckeditor-image-style-alignment');
+          this.parts.image.removeAttribute('data-xwiki-image-style-alignment');
         }
 
         if (this.data.textWrap) {
-          this.parts.image.setAttribute('data-ckeditor-image-style-text-wrap', this.data.textWrap);
+          this.parts.image.setAttribute('data-xwiki-image-style-text-wrap', this.data.textWrap);
         } else {
-          this.parts.image.removeAttribute('data-ckeditor-image-style-text-wrap');
+          this.parts.image.removeAttribute('data-xwiki-image-style-text-wrap');
         }
 
         originalData.call(this);

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
@@ -17,224 +17,117 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-(function (){
+(function() {
   'use strict';
 
-  // Declare the configuration namespace.
-  CKEDITOR.config['xwiki-image'] = CKEDITOR.config['xwiki-image'] || {
-    __namespace: true
-  };
+  function showImageWizard(editor, widget) {
+    require(['imageWizard'], function(imageWizard) {
+      imageWizard({
+        editor: editor,
+        macroData: widget.data
+      }).done(function(data) {
+        if (widget && widget.element) {
+          widget.setData(data);
+        } else {
+          var element = CKEDITOR.dom.element.createFromHtml(widget.template.output(), editor.document);
+          var wrapper = editor.widgets.wrapElement(element, widget.name);
+          var temp = new CKEDITOR.dom.documentFragment(wrapper.getDocument());
+
+          // Append wrapper to a temporary document. This will unify the environment in which #data listeners work when
+          // creating and editing widget.
+          temp.append(wrapper);
+
+          var instance = editor.widgets.initOn(element, widget, {});
+          instance.edit();
+          editor.widgets.initOn(element, widget, data);
+          editor.widgets.finalizeCreation(temp);
+        }
+      });
+    });
+  }
 
   CKEDITOR.plugins.add('xwiki-image', {
-    requires: 'xwiki-marker,xwiki-resource,balloontoolbar',
-
-    beforeInit: function(editor) {
-      editor.on('widgetDefinition', function (event) {
-        var widgetDefinition = event.data;
-        if (widgetDefinition.name === "image" && widgetDefinition.dialog === "image2") {
-          this.overrideImageWidget(editor, widgetDefinition);
-        }
-      }, this);
-    },
-
+    requires: 'xwiki-image-old', // TODO: maybe require modal to have skinx?
     init: function(editor) {
-      editor.plugins['xwiki-marker'].addMarkerHandler(editor, 'image', {
-        // startImageComment: CKEDITOR.htmlParser.comment
-        // content: CKEDITOR.htmlParser.node[]
-        toHtml: function(startImageComment, content) {
-          if (content.length === 1 && content[0].name === 'img') {
-            var image = content[0];
-            // Protect the image rendering markers by saving their data on the image element itself.
-            var reference = startImageComment.value.substring('startimage:'.length);
-            image.attributes['data-reference'] = CKEDITOR.tools.unescapeComment(reference);
-            // Handle free-standing images.
-            if (image.hasClass('wikimodel-freestanding')) {
-              image.attributes['data-freestanding'] = true;
-              // This is an internal class that should not be visible when editing the image.
-              image.removeClass('wikimodel-freestanding');
-              // The alt attribute is auto-generated for free-standing images. We remove it in order to be consistent
-              // with the wiki syntax where it's not specified.
-              delete image.attributes.alt;
-            }
-          } else {
-            // Unexpected HTML structure inside image markers. Keep the markers.
-            return false;
-          }
-        },
-        // element: CKEDITOR.htmlParser.element
-        isMarked: function(element) {
-          return element.name === 'img' && element.attributes['data-reference'];
-        },
-        // image: CKEDITOR.htmlParser.element
-        toDataFormat: function(image) {
-          // Put back the image rendering markers.
-          var reference = CKEDITOR.tools.escapeComment(image.attributes['data-reference']);
-          var startImageComment = new CKEDITOR.htmlParser.comment('startimage:' + reference);
-          var stopImageComment = new CKEDITOR.htmlParser.comment('stopimage');
-          startImageComment.insertBefore(image);
-          stopImageComment.insertAfter(image);
-          delete image.attributes['data-reference'];
-          // Handle free-standing images.
-          var freeStanding = image.attributes['data-freestanding'] === 'true';
-          delete image.attributes['data-freestanding'];
-          // Free-standing images don't have white-space in their reference and have only the src attribute set.
-          if (freeStanding && !/\s+/.test(reference) && isFreeStandingImage(image)) {
-            image.addClass('wikimodel-freestanding');
-          }
-        }
-      });
-
-      editor.balloonToolbars.create({
-        buttons: 'Link,Unlink,Image',
-        widgets: 'image'
-      });
+      this.initImageDialogWidget(editor);
     },
+    initImageDialogWidget: function(editor) {
+      var imagePlugin = this;
+      var imageWidget = editor.widgets.registered.image;
+      this.overrideImageWidget(editor, imageWidget);
 
+      imageWidget.insert = function() {
+        showImageWizard(editor, this);
+      };
+      imageWidget.edit = function(event) {
+        // Prevent the default behavior because we want to use our custom image dialog.
+        event.cancel();
+        showImageWizard(editor, this);
+      };
+    },
     overrideImageWidget: function(editor, imageWidget) {
+      CKEDITOR.plugins.registered['xwiki-image-old'].overrideImageWidget(editor, imageWidget);
+
       var originalInit = imageWidget.init;
       imageWidget.init = function() {
         originalInit.call(this);
-        var serializedResourceReference = this.parts.image.getAttribute('data-reference');
-        if (serializedResourceReference) {
-          this.setData('resourceReference', CKEDITOR.plugins.xwikiResource
-            .parseResourceReference(serializedResourceReference));
+
+        // Caption
+        if (this.parts.caption) {
+          this.setData('hasCaption', true);
+          // TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
+          //this.setData('imageCaption', this.parts.caption.getText())
+        } else {
+          this.setData('hasCaption', false);
         }
+
+        // Style
+        this.setData('imageStyle', this.parts.image.getAttribute('data-ckeditor-image-style'));
+
+        this.setData('border', this.parts.image.getAttribute('data-ckeditor-image-style-border'));
+        this.setData('alignment', this.parts.image.getAttribute('data-ckeditor-image-style-alignment') || 'none');
+        this.setData('textWrap', this.parts.image.getAttribute('data-ckeditor-image-style-textWrap'));
       };
 
       var originalData = imageWidget.data;
       imageWidget.data = function() {
-        var resourceReference = this.data.resourceReference;
-        if (resourceReference) {
-          this.parts.image.setAttribute('data-reference', CKEDITOR.plugins.xwikiResource
-            .serializeResourceReference(resourceReference));
+
+
+        // Caption
+        // TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
+        /*if(this.data.hasCaption && this.parts.caption) {
+          
+           //this.parts.caption.setHtml('<p>'+this.data.imageCaption+'</p>');
+        }*/
+
+        // Style
+        if (this.data.imageStyle) {
+          this.parts.image.setAttribute('data-ckeditor-image-style', this.data.imageStyle);
+        } else {
+          this.parts.image.removeAttribute('data-ckeditor-image-style');
         }
+
+        if (this.data.border) {
+          this.parts.image.setAttribute('data-ckeditor-image-style-border', this.data.border);
+        } else {
+          this.parts.image.removeAttribute('data-ckeditor-image-style-border');
+        }
+
+        if (this.data.alignment && this.data.alignment !== 'none') {
+          this.parts.image.setAttribute('data-ckeditor-image-style-alignment', this.data.alignment);
+        } else {
+          this.parts.image.removeAttribute('data-ckeditor-image-style-alignment');
+        }
+
+        if (this.data.textWrap) {
+          this.parts.image.setAttribute('data-ckeditor-image-style-textWrap', this.data.textWrap);
+        } else {
+          this.parts.image.removeAttribute('data-ckeditor-image-style-textWrap');
+        }
+
         originalData.call(this);
       };
-
-      // Adds support for configuring the allowed content for image caption (currently hard-coded).
-      var captionAllowedContent = (editor.config['xwiki-image'] || {}).captionAllowedContent;
-      if (captionAllowedContent) {
-        imageWidget.editables.caption.allowedContent = captionAllowedContent;
-      }
-
-      //
-      // Don't remove the width/height if they are specified using percentage.
-      // See CKEDITOR-122: CKEditor removes image width when specified as percentage
-      //
-
-      // @param {CKEDITOR.htmlParser.element} image
-      // @param {String} dimension ('width' or 'height')
-      var maybeProtectDimension = function(image, dimension) {
-        var value = typeof image.attributes[dimension] === 'string' && image.attributes[dimension].trim();
-        if (value.length && value.charAt(value.length - 1) === '%') {
-          image[dimension + '%'] = image.attributes[dimension];
-          delete image.attributes[dimension];
-          return true;
-        }
-      };
-
-      // @param {CKEDITOR.htmlParser.element} image
-      // @param {String} dimension ('width' or 'height')
-      var maybeUnprotectDimension = function(image, dimension) {
-        if (image[dimension + '%']) {
-          image.attributes[dimension] = image[dimension + '%'];
-          delete image[dimension + '%'];
-        }
-      };
-
-      var originalUpcast = imageWidget.upcast;
-      // @param {CKEDITOR.htmlParser.element} element
-      // @param {Object} data
-      imageWidget.upcast = function(element, data) {
-        var imagesUsingPercent = [];
-        element.forEach(function(childElement) {
-          // Note that we're using the Bitwise OR (|) operator because we want to protect both attributes.
-          if (element.name === 'img' && (maybeProtectDimension(element, 'width') |
-              maybeProtectDimension(element, 'height'))) {
-            imagesUsingPercent.push(element);
-          }
-        }, CKEDITOR.NODE_ELEMENT);
-        try {
-          return originalUpcast.apply(this, arguments);
-        } finally {
-          imagesUsingPercent.forEach(function(image) {
-            maybeUnprotectDimension(image, 'width');
-            maybeUnprotectDimension(image, 'height');
-          });
-        }
-      };
     }
   });
 
-  CKEDITOR.on('dialogDefinition', function(event) {
-    // Make sure we affect only the editors that load this plugin.
-    if (!event.editor.plugins['xwiki-image']) {
-      return;
-    }
-
-    // Take the dialog window name and its definition from the event data.
-    var dialogName = event.data.name;
-    var dialogDefinition = event.data.definition;
-    if (dialogName === 'image2') {
-      replaceWithResourcePicker(dialogDefinition, 'src', {
-        resourceTypes: (event.editor.config['xwiki-image'] || {}).resourceTypes || ['attach', 'icon', 'url'],
-        setup: function(widget) {
-          this.setValue(widget.data.resourceReference);
-        },
-        commit: function(widget) {
-          var oldResourceReference = widget.data.resourceReference || {};
-          var newResourceReference = this.getValue();
-          if (oldResourceReference.type !== newResourceReference.type ||
-              oldResourceReference.reference !== newResourceReference.reference) {
-            newResourceReference.typed = newResourceReference.type !== 'attach' &&
-              (newResourceReference.type !== 'url' || newResourceReference.reference.indexOf('://') < 0);
-            widget.setData('resourceReference', CKEDITOR.tools.extend(newResourceReference, oldResourceReference));
-          }
-        }
-      });
-      CKEDITOR.plugins.xwikiResource.updateResourcePickerOnFileBrowserSelect(dialogDefinition,
-        ['info', 'resourceReference'], ['Upload', 'uploadButton']);
-
-      // See CKEDITOR-122: CKEditor removes image width when specified as percentage
-      allowRelativeDimensions(dialogDefinition);
-    }
-  });
-
-  var replaceWithResourcePicker = function(dialogDefinition, replacedElementId, pickerDefinition) {
-    var path = CKEDITOR.plugins.xwikiDialog.getUIElementPath(replacedElementId, dialogDefinition.contents);
-    if (path && path.length > 2) {
-      pickerDefinition = CKEDITOR.plugins.xwikiResource.createResourcePicker(pickerDefinition);
-      // Bind the replaced element to the resource picker (in order to commit the resource picker value).
-      var tabId = path[path.length - 1].element.id;
-      CKEDITOR.plugins.xwikiResource.bindResourcePicker(path[0].element, [tabId, pickerDefinition.id]);
-      // Hide the parent.
-      path[1].element.hidden = true;
-      // Insert the new element before the hidden parent.
-      path[2].element.children.splice(path[1].position, 0, pickerDefinition);
-    }
-  };
-
-  var allowRelativeDimensions = function(imageDialog) {
-    var infoTab = imageDialog.getContents('info');
-    allowRelativeDimension(infoTab, 'width');
-    allowRelativeDimension(infoTab, 'height');
-  };
-
-  var regexPercent = /^\s*(\d+\%)\s*$/i;
-  var allowRelativeDimension = function(infoTab, dimension) {
-    var originalValidate = infoTab.get(dimension).validate;
-    infoTab.get(dimension).validate = function() {
-      return this.getValue().match(regexPercent) || originalValidate.apply(this, arguments);
-    };
-  };
-
-  // Free-standing images have only the source attribute set.
-  var isFreeStandingImage = function(image) {
-    for (var attribute in image.attributes) {
-      if (image.attributes.hasOwnProperty(attribute) && attribute !== 'src' && image.attributes[attribute] !== '') {
-        return false;
-      }
-    }
-    return true;
-  };
 })();

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
@@ -81,7 +81,7 @@
         }
 
         // Style
-        this.setData('imageStyle', this.parts.image.getAttribute('data-xwiki-image-style'));
+        this.setData('imageStyle', this.parts.image.getAttribute('data-xwiki-image-style') || '');
 
         this.setData('border', this.parts.image.getAttribute('data-xwiki-image-style-border'));
         this.setData('alignment', this.parts.image.getAttribute('data-xwiki-image-style-alignment') || 'none');

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/plugin.js
@@ -38,7 +38,7 @@
           temp.append(wrapper);
 
           var instance = editor.widgets.initOn(element, widget, {});
-          instance.edit();
+          instance.setData(data);
           editor.widgets.initOn(element, widget, data);
           editor.widgets.finalizeCreation(temp);
         }

--- a/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
@@ -377,32 +377,6 @@ define('macroParameterTreeSorter', ['jquery'], function($) {
 });
 
 /**
- * Utility module to load required skin extensions.
- */
-define('xwiki-skinx', ['jquery'], function($) {
-  $.fn.loadRequiredSkinExtensions = function(requiredSkinExtensions) {
-    return this.each(function() {
-      // 'this' can be an element, the window or the document itself.
-      var ownerDocument = this.ownerDocument || this.document || this;
-      var head = $(ownerDocument).find('head');
-      var existingSkinExtensions;
-      var getExistingSkinExtensions = function() {
-        return head.find('link, script').map(function() {
-          return $(this).attr('href') || $(this).attr('src');
-        }).get();
-      };
-      $('<div></div>').html(requiredSkinExtensions).find('link, script').filter(function() {
-        if (!existingSkinExtensions) {
-          existingSkinExtensions = getExistingSkinExtensions();
-        }
-        var url = $(this).attr('href') || $(this).attr('src');
-        return existingSkinExtensions.indexOf(url) < 0;
-      }).appendTo(head);
-    });
-  };
-});
-
-/**
  * Macro Parameter Tree Displayer
  */
 define('macroParameterTreeDisplayer', ['jquery', 'l10n!macroEditor', 'xwiki-skinx'], function($, translations) {

--- a/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
@@ -379,7 +379,7 @@ define('macroParameterTreeSorter', ['jquery'], function($) {
 /**
  * Macro Parameter Tree Displayer
  */
-define('macroParameterTreeDisplayer', ['jquery', 'l10n!macroEditor', 'xwiki-skinx'], function($, translations) {
+define('macroParameterTreeDisplayer', ['jquery', 'l10n!macroEditor'], function($, translations) {
   'use strict';
 
   var displayMacroParameterTree = function(macroParameterTree, requiredSkinExtensions) {

--- a/application-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
@@ -64,7 +64,8 @@
   };
 
   CKEDITOR.plugins.add('xwiki-macro', {
-    requires: 'widget,balloontoolbar,notification,xwiki-marker,xwiki-loading,xwiki-localization,xwiki-selection',
+    requires: 'widget,balloontoolbar,notification,xwiki-marker,xwiki-loading,xwiki-localization,xwiki-selection,' +
+      'xwiki-dialog',
 
     init: function(editor) {
       var macroPlugin = this;

--- a/application-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
@@ -64,8 +64,10 @@
   };
 
   CKEDITOR.plugins.add('xwiki-macro', {
-    requires: 'widget,balloontoolbar,notification,xwiki-marker,xwiki-loading,xwiki-localization,xwiki-selection,' +
-      'xwiki-dialog',
+    // CKEditor build fails if the requires string contains a concatenation. To match the line length limit, the string
+    // is moved one line down.
+    requires: 
+      'widget,balloontoolbar,notification,xwiki-marker,xwiki-loading,xwiki-localization,xwiki-selection,xwiki-dialog',
 
     init: function(editor) {
       var macroPlugin = this;

--- a/application-ckeditor-plugins/src/main/resources/xwiki-office/plugin.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-office/plugin.js
@@ -51,7 +51,7 @@ define('officeImporterModal', ['jquery', 'modal'], function($, $modal) {
   };
 
   CKEDITOR.plugins.add('xwiki-office', {
-    requires: 'uploadwidget,notification,xwiki-localization,xwiki-macro',
+    requires: 'uploadwidget,notification,xwiki-localization,xwiki-macro,xwiki-dialog',
 
     init : function(editor) {
       var officeImporterURL = (editor.config['xwiki-office'] || {}).importer;

--- a/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
@@ -161,6 +161,7 @@
 #set ($ckeditorBasePath = $stringtool.removeEnd($stringtool.removeEnd($ckeditorPath, '.js'), 'ckeditor'))
 #set ($resourcePickerBundlePath = "${ckeditorBasePath}plugins/xwiki-resource/resourcePicker.bundle.min")
 #set ($macroWizardBundlePath = "${ckeditorBasePath}plugins/xwiki-macro/macroWizard.bundle.min")
+#set ($imageWizardBundlePath = "${ckeditorBasePath}plugins/xwiki-image/imageWizard.bundle.min")
 #set ($modalPath = "${ckeditorBasePath}plugins/xwiki-dialog/modal.min")
 #set ($l10nPath = "${ckeditorBasePath}plugins/xwiki-localization/l10n.min")
 */
@@ -171,6 +172,7 @@ require.config({
     modal: '$!modalPath',
     l10n: '$!l10nPath',
     macroWizard: '$!macroWizardBundlePath',
+    imageWizard: '$!imageWizardBundlePath',
     // This is used by the resource suggest picker on the link modal.
     'bootstrap3-typeahead': $jsontool.serialize($services.webjars.url('org.webjars.npm:bootstrap-3-typeahead',
       'bootstrap3-typeahead.min')),
@@ -185,7 +187,7 @@ require.config({
     ckeditor: {
       exports: 'CKEDITOR',
       // This includes dependencies of the plugins bundled with the CKEditor code.
-      deps: ['jquery', 'resource', 'resourcePicker', 'macroWizard']
+      deps: ['jquery', 'resource', 'resourcePicker', 'macroWizard', 'imageWizard']
     }
   },
   config: {

--- a/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
@@ -170,7 +170,6 @@ require.config({
     ckeditor: '$!ckeditorPath',
     resourcePickerBundle: '$!resourcePickerBundlePath',
     modal: '$!modalPath',
-    'xwiki-skinx': '$!modalPath',
     l10n: '$!l10nPath',
     macroWizard: '$!macroWizardBundlePath',
     imageWizard: '$!imageWizardBundlePath',

--- a/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
@@ -170,6 +170,7 @@ require.config({
     ckeditor: '$!ckeditorPath',
     resourcePickerBundle: '$!resourcePickerBundlePath',
     modal: '$!modalPath',
+    'xwiki-skinx': '$!modalPath',
     l10n: '$!l10nPath',
     macroWizard: '$!macroWizardBundlePath',
     imageWizard: '$!imageWizardBundlePath',

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageEditorService.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageEditorService.xml
@@ -40,8 +40,8 @@
   <hidden>true</hidden>
   <content>{{velocity output='false'}}
 #if ($xcontext.action == 'get')
-#template('display_macros.vm')
-#initRequiredSkinExtensions()
+  #template('display_macros.vm')
+  #initRequiredSkinExtensions()
 #end
 {{/velocity}}
 
@@ -50,7 +50,7 @@
 ## Expected request parameters:
 ## - isHTML5: true when htm5 is supported
 ##
-## Check if the default image styles are available.
+## Check if the image styles are available.
 #if ($services.component.getInstance('org.xwiki.rest.XWikiRestComponent', 'org.xwiki.image.style.rest.internal.DefaultImageStylesResource'))
   #set ($defaultImageStylesActive = true)
 #else
@@ -88,7 +88,8 @@
           &lt;/span&gt;
         &lt;/dt&gt;
         &lt;dd&gt;
-          #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'), {'type': 'text/css', 'rel': 'stylesheet'}))
+          #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'), 
+            {'type': 'text/css', 'rel': 'stylesheet'}))
           #set ($discard = $xwiki.ssfx.use('uicomponents/suggest/xwiki.selectize.css', true))
           #set ($discard = $xwiki.jsx.use('CKEditor.ImageEditorService'))
           &lt;select id="imageStyles"&gt;&lt;/select&gt;
@@ -105,7 +106,7 @@
         &lt;dd&gt;
           &lt;input id="altText" name="altText" value="" type="text" /&gt;
         &lt;/dd&gt;
-        #if ("${request.isHTML5}" == 'true')
+        #if ($request.isHTML5 == 'true')
         &lt;dt&gt;
           &lt;label for="imageCaptionActivation"&gt;
             $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.caption.label'))
@@ -119,12 +120,7 @@
             &lt;input type="checkbox" 
               aria-label="$escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.caption.ariaLabel'))"
               id="imageCaptionActivation" /&gt;
-          &lt;!-- TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
-            &lt;span class="input-group-addon" name="imageCaptionActivation"/&gt;
-              &lt;input type="checkbox" aria-label="TODO Image caption activation checkbox" id="imageCaptionActivation" /&gt;
-            &lt;/span&gt;
-            &lt;input type="text" class="form-control" aria-label="Image caption text input" id="imageCaption" name="imageCaption" disabled/&gt;
-          &lt;/div&gt;--&gt;
+          &lt;!-- TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435) -->
         &lt;/dd&gt;
         #end
       &lt;/dl&gt;
@@ -210,8 +206,8 @@
 
 {{velocity output='false'}}
 #if ($xcontext.action == 'get')
-#getRequiredSkinExtensions($requiredSkinExtensions)
-#set ($discard = $response.setHeader('X-XWIKI-HTML-HEAD', $requiredSkinExtensions))
+  #getRequiredSkinExtensions($requiredSkinExtensions)
+  #set ($discard = $response.setHeader('X-XWIKI-HTML-HEAD', $requiredSkinExtensions))
 #end
 {{/velocity}}</content>
 </xwikidoc>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageEditorService.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageEditorService.xml
@@ -51,7 +51,7 @@
 ## - isHTML5: true when htm5 is supported
 ##
 ## Check if the image styles are available.
-#if ($services.component.getInstance('org.xwiki.rest.XWikiRestComponent', 'org.xwiki.image.style.rest.internal.DefaultImageStylesResource'))
+#if ($services.imageStyle)
   #set ($defaultImageStylesActive = true)
 #else
   #set ($defaultImageStylesActive = false)
@@ -120,7 +120,7 @@
             &lt;input type="checkbox" 
               aria-label="$escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.caption.ariaLabel'))"
               id="imageCaptionActivation" /&gt;
-          &lt;!-- TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435) -->
+          &lt;!-- TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435) --&gt;
         &lt;/dd&gt;
         #end
       &lt;/dl&gt;
@@ -199,6 +199,10 @@
       &lt;/form&gt;
     &lt;/div&gt;
   &lt;/div&gt;
+  &lt;input type="hidden" name="defaultImageStylesRestURL" id="defaultImageStylesRestURL"
+    value="$services.imageStyle.getDefaultImageStyleRestPath()" /&gt;
+  &lt;input type="hidden" name="imageStylesRestURL" id="imageStylesRestURL"
+      value="$services.imageStyle.getImageStylesRestPath()" /&gt;
 &lt;/div&gt;
 {{/html}}
 #end

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageEditorService.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageEditorService.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.3" reference="CKEditor.ImageEditorService" locale="">
+  <web>CKEditor</web>
+  <name>ImageEditorService</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1648816215000</creationDate>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1649255194000</date>
+  <contentUpdateDate>1649255194000</contentUpdateDate>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity output='false'}}
+#if ($xcontext.action == 'get')
+#template('display_macros.vm')
+#initRequiredSkinExtensions()
+#end
+{{/velocity}}
+
+{{velocity}}
+##
+## Expected request parameters:
+## - isHTML5: true when htm5 is supported
+##
+## Check if the default image styles are available.
+#if ($services.component.getInstance('org.xwiki.rest.XWikiRestComponent', 'org.xwiki.image.style.rest.internal.DefaultImageStylesResource'))
+  #set ($defaultImageStylesActive = true)
+#else
+  #set ($defaultImageStylesActive = false)
+#end
+#if ($xcontext.action == 'get')
+{{html clean='false'}}
+&lt;div&gt;
+  &lt;!-- Nav tabs --&gt;
+  &lt;ul class="nav nav-tabs" role="tablist"&gt;
+    &lt;li role="presentation" class="active"&gt;
+      &lt;a href="#standard" aria-controls="standard" role="tab" data-toggle="tab"&gt;
+        $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.title'))
+      &lt;/a&gt;
+    &lt;/li&gt;
+    &lt;li role="presentation"&gt;
+      &lt;a href="#advanced" aria-controls="advanced" role="tab" data-toggle="tab"&gt;
+        $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.title'))
+      &lt;/a&gt;
+    &lt;/li&gt;
+  &lt;/ul&gt;
+
+  &lt;!-- Tab panes --&gt;
+  &lt;div class="tab-content"&gt;
+    &lt;div role="tabpanel" class="tab-pane active" id="standard"&gt;
+     &lt;form class="xform"&gt;
+     &lt;dl&gt;
+       #if ($defaultImageStylesActive)
+        &lt;dt&gt;
+          &lt;label for="imageStyles"&gt;
+            $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.imageStyles.label'))
+          &lt;/label&gt;
+          &lt;span class="xHint"&gt;
+            $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.imageStyles.hint'))
+          &lt;/span&gt;
+        &lt;/dt&gt;
+        &lt;dd&gt;
+          #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'), {'type': 'text/css', 'rel': 'stylesheet'}))
+          #set ($discard = $xwiki.ssfx.use('uicomponents/suggest/xwiki.selectize.css', true))
+          #set ($discard = $xwiki.jsx.use('CKEditor.ImageEditorService'))
+          &lt;select id="imageStyles"&gt;&lt;/select&gt;
+        &lt;/dd&gt;
+       #end
+        &lt;dt&gt;
+          &lt;label for="altText"&gt;
+            $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.alt.label'))
+          &lt;/label&gt;
+          &lt;span class="xHint"&gt;
+            $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.alt.hint'))
+          &lt;/span&gt;
+        &lt;/dt&gt;
+        &lt;dd&gt;
+          &lt;input id="altText" name="altText" value="" type="text" /&gt;
+        &lt;/dd&gt;
+        #if ("${request.isHTML5}" == 'true')
+        &lt;dt&gt;
+          &lt;label for="imageCaptionActivation"&gt;
+            $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.caption.label'))
+          &lt;/label&gt;
+          &lt;span class="xHint"&gt;
+            $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.caption.hint'))
+          &lt;/span&gt;
+        &lt;/dt&gt;
+        &lt;dd&gt;
+          &lt;div class="input-group"&gt;
+            &lt;input type="checkbox" 
+              aria-label="$escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.standardTab.caption.ariaLabel'))"
+              id="imageCaptionActivation" /&gt;
+          &lt;!-- TODO: Add support for editing the caption directly from the dialog (see CKEDITOR-435)
+            &lt;span class="input-group-addon" name="imageCaptionActivation"/&gt;
+              &lt;input type="checkbox" aria-label="TODO Image caption activation checkbox" id="imageCaptionActivation" /&gt;
+            &lt;/span&gt;
+            &lt;input type="text" class="form-control" aria-label="Image caption text input" id="imageCaption" name="imageCaption" disabled/&gt;
+          &lt;/div&gt;--&gt;
+        &lt;/dd&gt;
+        #end
+      &lt;/dl&gt;
+     &lt;/form&gt;
+    &lt;/div&gt;
+    &lt;div role="tabpanel" class="tab-pane" id="advanced"&gt;
+      &lt;form class="xform"&gt;
+        &lt;dl&gt;
+          &lt;dt&gt;
+            &lt;label&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.size.label'))
+            &lt;/label&gt;
+            &lt;span class="xHint"&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.size.hint'))
+            &lt;/span&gt;
+          &lt;/dt&gt;
+          &lt;dd&gt;
+            &lt;label&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.size.width.label'))
+              &lt;input type="number" name="imageWidth" id="imageWidth" /&gt;
+            &lt;/label&gt;
+            &lt;label&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.size.height.label'))
+              &lt;input type="number" name="imageHeight" id="imageHeight" /&gt;
+            &lt;/label&gt;
+          &lt;/dd&gt;
+          &lt;dt&gt;
+            &lt;label for="imageBorder"&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.border.label'))
+            &lt;/label&gt;
+            &lt;span class="xHint"&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.border.hint'))
+            &lt;/span&gt;
+          &lt;/dt&gt;
+          &lt;dd&gt;
+            &lt;input type="checkbox" name="imageBorder" id="imageBorder" /&gt;
+          &lt;/dd&gt;
+          &lt;dt&gt;
+            &lt;label for="imageAlignment"&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.label'))
+            &lt;/label&gt;
+            &lt;span class="xHint"&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.hint'))
+            &lt;/span&gt;
+          &lt;/dt&gt;
+          &lt;dd&gt;
+            &lt;label&gt;
+              &lt;input type="radio" name="alignment" value="none"/&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.none'))
+            &lt;/label&gt;
+            &lt;label&gt;
+              &lt;input type="radio" name="alignment" value="left"/&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.left'))
+            &lt;/label&gt;
+            &lt;label&gt;
+              &lt;input type="radio" name="alignment" value="center"/&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.center'))
+            &lt;/label&gt;
+            &lt;label&gt;
+              &lt;input type="radio" name="alignment" value="right"/&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.right'))
+            &lt;/label&gt;
+          &lt;/dd&gt;
+          &lt;dt&gt;
+            &lt;label for="textWrap"&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.textWrap.label'))
+            &lt;/label&gt;
+            &lt;span class="xHint"&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.textWrap.hint'))
+            &lt;/span&gt;
+          &lt;/dt&gt;
+          &lt;dd&gt;
+            &lt;input type="checkbox" name="textWrap" id="textWrap" /&gt;
+          &lt;/dd&gt;
+        &lt;/dl&gt;
+      &lt;/form&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+{{/html}}
+#end
+{{/velocity}}
+
+{{velocity output='false'}}
+#if ($xcontext.action == 'get')
+#getRequiredSkinExtensions($requiredSkinExtensions)
+#set ($discard = $response.setHeader('X-XWIKI-HTML-HEAD', $requiredSkinExtensions))
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageEditorService.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageEditorService.xml
@@ -176,16 +176,16 @@
               $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.none'))
             &lt;/label&gt;
             &lt;label&gt;
-              &lt;input type="radio" name="alignment" value="left"/&gt;
-              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.left'))
+              &lt;input type="radio" name="alignment" value="start"/&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.start'))
             &lt;/label&gt;
             &lt;label&gt;
               &lt;input type="radio" name="alignment" value="center"/&gt;
               $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.center'))
             &lt;/label&gt;
             &lt;label&gt;
-              &lt;input type="radio" name="alignment" value="right"/&gt;
-              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.right'))
+              &lt;input type="radio" name="alignment" value="end"/&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.end'))
             &lt;/label&gt;
           &lt;/dd&gt;
           &lt;dt&gt;

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
@@ -40,8 +40,8 @@
   <hidden>true</hidden>
   <content>{{velocity output="false"}}
 #if ($xcontext.action == 'get')
-#template('display_macros.vm')
-#initRequiredSkinExtensions()
+  #template('display_macros.vm')
+  #initRequiredSkinExtensions()
 #end
 {{/velocity}}
 
@@ -106,8 +106,8 @@
 
 {{velocity output="false"}}
 #if ($xcontext.action == 'get')
-#getRequiredSkinExtensions($requiredSkinExtensions)
-#set ($discard = $response.setHeader('X-XWIKI-HTML-HEAD', $requiredSkinExtensions))
+  #getRequiredSkinExtensions($requiredSkinExtensions)
+  #set ($discard = $response.setHeader('X-XWIKI-HTML-HEAD', $requiredSkinExtensions))
 #end
 {{/velocity}}</content>
 </xwikidoc>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.3" reference="CKEditor.ImageSelectorService" locale="">
+  <web>CKEditor</web>
+  <name>ImageSelectorService</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1648816214000</creationDate>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1649343095000</date>
+  <contentUpdateDate>1649343095000</contentUpdateDate>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity output="false"}}
+#if ($xcontext.action == 'get')
+#template('display_macros.vm')
+#initRequiredSkinExtensions()
+#end
+{{/velocity}}
+
+{{velocity}}
+#if ($xcontext.action == 'get')
+{{html clean='false'}}
+&lt;div&gt;
+  &lt;!-- Nav tabs --&gt;
+  &lt;ul class="nav nav-tabs" role="tablist"&gt;
+    &lt;li role="presentation" class="active"&gt;
+      &lt;a href="#documentTree" aria-controls="documentTree" role="tab" data-toggle="tab"&gt;
+        $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.documentTreeTab.title'))
+      &lt;/a&gt;
+    &lt;/li&gt;
+    &lt;li role="presentation"&gt;
+      &lt;a href="#upload" aria-controls="upload" role="tab" data-toggle="tab"&gt;
+        $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.title'))
+      &lt;/a&gt;
+    &lt;/li&gt;
+  &lt;/ul&gt;
+
+  &lt;!-- Tab panes --&gt;
+  &lt;div class="tab-content"&gt;
+    &lt;div role="tabpanel" class="tab-pane active" id="documentTree"&gt;
+      #template('documentTree_macros.vm')
+      #documentTree({
+        'class': 'attachments-tree',
+        'finder': true,
+        'openTo': "document:$services.model.serialize($doc.documentReference, 'default')",
+        'showWikis': true,
+        'showTranslations': false
+      })
+    &lt;/div&gt;
+    &lt;div role="tabpanel" class="tab-pane" id="upload"&gt;
+      &lt;form class="xform"&gt;
+        &lt;dl&gt;
+          &lt;dt&gt;
+            &lt;label for="fileUploadField"&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.title'))
+            &lt;/label&gt;
+            &lt;span class="xHint"&gt;
+              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.hint'))
+            &lt;/span&gt;
+          &lt;/dt&gt;
+          &lt;dd&gt;
+            &lt;input id="fileUploadField" name="fileUploadField" type="file" accept="image/*"/&gt;
+          &lt;/dd&gt;
+        &lt;/dl&gt;
+        &lt;p&gt;
+          &lt;span class="buttonwrapper"&gt;
+            &lt;input class="button" type="submit"
+              value="$escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.uploadButton'))"/&gt;
+          &lt;/span&gt;
+        &lt;/p&gt;
+      &lt;/form&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+{{/html}}
+#end
+{{/velocity}}
+
+{{velocity output="false"}}
+#if ($xcontext.action == 'get')
+#getRequiredSkinExtensions($requiredSkinExtensions)
+#set ($discard = $response.setHeader('X-XWIKI-HTML-HEAD', $requiredSkinExtensions))
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -133,11 +133,11 @@ ckeditor.plugin.image.imageEditor.advancedTab.border.hint=When checked, the imag
 ckeditor.plugin.image.imageEditor.advancedTab.alignment.label=Alignment
 ckeditor.plugin.image.imageEditor.advancedTab.alignment.hint=Define the image alignment.
 ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.none=None
-ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.left=Left
+ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.start=Start
 ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.center=Center
-ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.right=Right
+ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.end=End
 ckeditor.plugin.image.imageEditor.advancedTab.textWrap.label=Text Wrap
-ckeditor.plugin.image.imageEditor.advancedTab.textWrap.hint=When checked, the image is wraped around the surounding text.
+ckeditor.plugin.image.imageEditor.advancedTab.textWrap.hint=When checked, the image is wrapped around the surrounding text.
 
 ckeditor.plugin.image.imageSelector.documentTreeTab.title=Document Tree
 ckeditor.plugin.image.imageSelector.uploadTab.title=Upload

--- a/application-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -202,10 +202,16 @@ imageEditor.modal.backToEditor.button=Back
 imageEditor.modal.loadFail.message=Failed to retrieve the image editor form.
 imageEditor.modal.title=Edit Image
 imageEditor.modal.insertButton=Insert
+imageEditor.modal.initialization.fail=Failed to retrieve the image selection form.
 
 imageSelector.modal.title=Select Image
 imageSelector.modal.selectButton=Select
-imageSelector.modal.loadFail.message=Failed to retrieve the image selection form.</content>
+imageSelector.modal.loadFail.message=Failed to retrieve the image selection form.
+imageSelector.modal.fileUpload.success=File upload succeeded.
+imageSelector.modal.fileUpload.fail=File upload failed.
+imageSelector.modal.fileUpload.abort=File upload aborted.
+imageSelector.modal.initialization.fail=Failed to retrieve the image selection form.
+</content>
   <object>
     <name>CKEditor.Translations</name>
     <number>0</number>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -114,6 +114,37 @@ ckeditor.plugin.syntax.update.done=WYSIWYG editor updated
 ckeditor.plugin.syntax.update.failed=Failed to update the WYSIWYG editor
 ckeditor.plugin.syntax.wysiwygModeUnsupported=The WYSIWYG edit mode is not supported by the {0} syntax.
 
+ckeditor.plugin.image.imageEditor.standardTab.title=Standard
+ckeditor.plugin.image.imageEditor.advancedTab.title=Advanced
+ckeditor.plugin.image.imageEditor.standardTab.imageStyles.label=Image Styles
+ckeditor.plugin.image.imageEditor.standardTab.imageStyles.hint=Select the style to apply on the image.
+ckeditor.plugin.image.imageEditor.standardTab.alt.label=Alternative Text
+ckeditor.plugin.image.imageEditor.standardTab.alt.hint=Define an alternate text for an image, if the image cannot be displayed.
+ckeditor.plugin.image.imageEditor.standardTab.caption.label=Caption
+ckeditor.plugin.image.imageEditor.standardTab.caption.hint=Activate and define an image caption.
+ckeditor.plugin.image.imageEditor.standardTab.caption.ariaLabel=Activate and define an image caption.
+
+ckeditor.plugin.image.imageEditor.advancedTab.size.label=Size
+ckeditor.plugin.image.imageEditor.advancedTab.size.width.label=Width
+ckeditor.plugin.image.imageEditor.advancedTab.size.height.label=Height
+ckeditor.plugin.image.imageEditor.advancedTab.size.hint=Define the image size.
+ckeditor.plugin.image.imageEditor.advancedTab.border.label=Border
+ckeditor.plugin.image.imageEditor.advancedTab.border.hint=When checked, the image is displayed with a border
+ckeditor.plugin.image.imageEditor.advancedTab.alignment.label=Alignment
+ckeditor.plugin.image.imageEditor.advancedTab.alignment.hint=Define the image alignment.
+ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.none=None
+ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.left=Left
+ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.center=Center
+ckeditor.plugin.image.imageEditor.advancedTab.alignment.option.right=Right
+ckeditor.plugin.image.imageEditor.advancedTab.textWrap.label=Text Wrap
+ckeditor.plugin.image.imageEditor.advancedTab.textWrap.hint=When checked, the image is wraped around the surounding text.
+
+ckeditor.plugin.image.imageSelector.documentTreeTab.title=Document Tree
+ckeditor.plugin.image.imageSelector.uploadTab.title=Upload
+ckeditor.plugin.image.imageSelector.uploadTab.file.title=File
+ckeditor.plugin.image.imageSelector.uploadTab.file.hint=Select a local file to add to the page.
+ckeditor.plugin.image.imageSelector.uploadTab.uploadButton=Upload
+
 ckeditor.inline.failedToInit=Failed to initialize CKEditor.
 
 ckeditor.upload.error.csrf=The CSRF token is missing.
@@ -164,7 +195,17 @@ macroEditor.changeMacro=Change Macro
 macroEditor.submit=Submit
 macroEditor.content=Content
 macroEditor.noParameters=This macro has no parameters.
-macroEditor.descriptorRequestFailed=Failed to retrieve the {0} macro descriptor.</content>
+macroEditor.descriptorRequestFailed=Failed to retrieve the {0} macro descriptor.
+
+
+imageEditor.modal.backToEditor.button=Back
+imageEditor.modal.loadFail.message=Failed to retrieve the image editor form.
+imageEditor.modal.title=Edit Image
+imageEditor.modal.insertButton=Insert
+
+imageSelector.modal.title=Select Image
+imageSelector.modal.selectButton=Select
+imageSelector.modal.loadFail.message=Failed to retrieve the image selection form.</content>
   <object>
     <name>CKEditor.Translations</name>
     <number>0</number>

--- a/application-ckeditor-webjar/src/main/config/build-config.js
+++ b/application-ckeditor-webjar/src/main/config/build-config.js
@@ -123,6 +123,7 @@ var CKBUILDER_CONFIG = {
     uploadimage: 1,
     wysiwygarea: 1,
     'xwiki-filter': 1,
+    'xwiki-image-old': 1,
     'xwiki-image': 1,
     'xwiki-link': 1,
     'xwiki-list': 1,

--- a/application-ckeditor-webjar/src/main/resources/config.js
+++ b/application-ckeditor-webjar/src/main/resources/config.js
@@ -117,6 +117,8 @@ CKEDITOR.editorConfig = function(config) {
       + 'officeImporter,xwiki-macro',
     // We remove the default sourcearea plugin because we use our own xwiki-sourcearea plugin which supports switching to
     // Source while editing in-place. We still bundle the sourcearea plugin because we reuse its icons and translations.
+    // We disable xwiki-image by default because the previous xwiki-image plugin has been renamed to xwiki-image-old, 
+    // and the new xwiki-image does not cover all the cases we need to support yet. 
     removePlugins: 'bidi,colorbutton,font,justify,save,sourcearea,xwiki-image',
     toolbarGroups: [
       {name: 'format'},

--- a/application-ckeditor-webjar/src/main/resources/config.js
+++ b/application-ckeditor-webjar/src/main/resources/config.js
@@ -117,7 +117,7 @@ CKEDITOR.editorConfig = function(config) {
       + 'officeImporter,xwiki-macro',
     // We remove the default sourcearea plugin because we use our own xwiki-sourcearea plugin which supports switching to
     // Source while editing in-place. We still bundle the sourcearea plugin because we reuse its icons and translations.
-    removePlugins: 'bidi,colorbutton,font,justify,save,sourcearea',
+    removePlugins: 'bidi,colorbutton,font,justify,save,sourcearea,xwiki-image',
     toolbarGroups: [
       {name: 'format'},
       {name: 'basicstyles', groups: ['basicstyles', 'cleanup']},


### PR DESCRIPTION
https://jira.xwiki.org/browse/CKEDITOR-436

- Provide the UI for:
  -  selecting an image with the document tree or by uploading an image
  - configuring the image:
    - basic:
      - style selection
      - alternative text 
      - caption
    - advanced:
      - size
      - border
      - alignment
      - text wrap

The new image dialog is currently deactivated by default (the previous `xwiki-image` plugin is now renamed `xwiki-image-old` and it activated by default).

![image](https://user-images.githubusercontent.com/327856/162394339-755af827-dfad-4d5f-9121-11372b03add3.png)
![image](https://user-images.githubusercontent.com/327856/162394374-b6be7235-60a5-4fa3-90f5-90eb21743f91.png)
![image](https://user-images.githubusercontent.com/327856/162394430-341573be-e2b5-4cc0-9c4c-194318b7a0f6.png)
![image](https://user-images.githubusercontent.com/327856/162394467-b069796b-ad6e-4651-8cb6-f72f3e78d88b.png)


