### PR TITLE
CKEDITOR-437: Introduce an UIXP for the image dialog search tabs

### DIFF
--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
@@ -32,63 +32,6 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector'],
   function($, $modal, resource, translations) {
     'use strict';
 
-    function getSelected(instance) {
-      /* jshint camelcase: false */
-      return instance.get_selected(false)[0];
-    }
-
-    function validateSelection(instance) {
-      var selected = getSelected(instance);
-      return selected && selected.startsWith("attachment:");
-    }
-
-    // TODO: should be loaded modularily and provided by the UIX for the image selector tab.
-    function initDocumentTree(modal) {
-      $('.attachments-tree').xtree()
-        .one('ready.jstree', function(event, data) {
-          data.instance.openTo("document:" + XWiki.Model.serialize(XWiki.currentDocument.getDocumentReference()));
-        })
-        .on('changed.jstree', function(event, data) {
-          if (validateSelection(data.instance)) {
-            saveSelectedImageReference(getSelected(data.instance), modal);
-          } else {
-            removeSelectedImageReference(modal);
-          }
-        });
-    }
-
-    function initDocumentUpload(editor, modal) {
-      $("#upload form input.button").on('click', function(event) {
-        event.preventDefault();
-        var loader = editor.uploadRepository.create($("#fileUploadField").prop('files')[0]);
-        var imageSelector = $('.image-selector');
-        loader.on('uploaded', function(evt) {
-          var resourceReference = evt.sender.responseData.message.resourceReference;
-          var entityReference = resource.convertResourceReferenceToEntityReference(resourceReference);
-          var serialized = XWiki.Model.serialize(entityReference);
-          saveSelectedImageReference(serialized, modal);
-          imageSelector.removeClass('loading');
-          new XWiki.widgets.Notification(translations.get('modal.fileUpload.success'), 'done');
-        });
-
-        // Return non-false value will disable fileButton in dialogui,
-        // below listeners takes care of such situation and re-enable "send" button.
-        loader.on('error', function(error) {
-          console.log('Failed to upload a file', error);
-          new XWiki.widgets.Notification(translations.get('modal.fileUpload.fail'), 'error');
-          imageSelector.removeClass('loading');
-        });
-        loader.on('abort', function(error) {
-          console.log('Failed to upload a file', error);
-          new XWiki.widgets.Notification(translations.get('modal.fileUpload.abort'), 'error');
-          imageSelector.removeClass('loading');
-        });
-
-        imageSelector.addClass('loading');
-        loader.loadAndUpload(editor.config.filebrowserUploadUrl);
-      });
-    }
-
     function getEntityReference(referenceStr) {
       var reference;
       if (referenceStr.startsWith("attachment:")) {
@@ -101,21 +44,27 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector'],
       return XWiki.Model.resolve(reference, XWiki.EntityType.ATTACHMENT);
     }
 
-    function saveSelectedImageReference(imageReference, modal) {
+    /**
+     * Can be called by the image selector tab UIXs. Indicates that an image has been selected.
+     *
+     * @param imageReference the selected image reference
+     */
+    function saveSelectedImageReference(imageReference) {
       modal.data('imageReference', {
         value: resource.convertEntityReferenceToResourceReference(getEntityReference(imageReference))
       });
       $('.image-selector-modal button.btn-primary').prop('disabled', false);
     }
 
-    function removeSelectedImageReference(modal) {
+    /**
+     * Can be called by the images selector tab UIXs. Indicated that no image is selected.
+     */
+    function removeSelectedImageReference() {
       modal.data('imageReference', {});
       $('.image-selector-modal button.btn-primary').prop('disabled', true);
     }
 
     function initialize(modal) {
-      var params = modal.data('input');
-
       if (!modal.data('initialized')) {
         var url = new XWiki.Document(XWiki.Model.resolve('CKEditor.ImageSelectorService', XWiki.EntityType.DOCUMENT))
           .getURL('get');
@@ -126,8 +75,7 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector'],
             $(document).loadRequiredSkinExtensions(requiredSkinExtensions);
             imageSelector.html(html);
             imageSelector.removeClass('loading');
-            initDocumentTree(modal);
-            initDocumentUpload(params.editor, modal);
+
             modal.data('initialized', true);
           }).fail(function(error) {
           console.log('Failed to retrieve the image selection form.', error);
@@ -137,18 +85,25 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector'],
       }
     }
 
+    function getEditor() {
+      return modal.data('input').editor;
+    }
+
+    // Defined once the modal is initialized.
+    var modal;
+
     // Initialize the modal.
-    return $modal.createModalStep({
+    var createModal = $modal.createModalStep({
       'class': 'image-selector-modal',
       title: translations.get('modal.title'),
       acceptLabel: translations.get('modal.selectButton'),
       content: '<div class="image-selector loading"></div>',
       onLoad: function() {
-        var modal = this;
+        modal = this;
         var selectButton = modal.find('.modal-footer .btn-primary');
         // Make the modal larger.
         modal.find('.modal-dialog').addClass('modal-lg');
-        
+
         modal.on('shown.bs.modal', function() {
           initialize(modal);
         });
@@ -167,4 +122,10 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector'],
         });
       }
     });
+    return {
+      createModal: createModal,
+      saveSelectedImageReference: saveSelectedImageReference,
+      removeSelectedImageReference: removeSelectedImageReference,
+      getEditor: getEditor
+    };
   });

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageSelector.js
@@ -54,6 +54,7 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector'],
     function updateSelectedImageReferences(imageReferences) {
       imageReferences = imageReferences || [];
       if(imageReferences.length > 0) {
+        // TODO:  Support the selection of several images (see CKEDITOR-445).
         var imageReference = imageReferences[0];
         modal.data('imageReference', {
           value: resource.convertEntityReferenceToResourceReference(getEntityReference(imageReference))

--- a/application-ckeditor-plugins/src/main/resources/xwiki-image/imageWizard.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-image/imageWizard.js
@@ -37,7 +37,7 @@ define('imageWizard', ['imageSelector', 'imageEditor'], function(imageSelector, 
   function selectAndEdit(params) {
     params = params || {};
     params.newImage = true;
-    return imageSelector.createModal(params)
+    return imageSelector.open(params)
       .then(imageEditor)
       .then(backToSelectionOrFinish);
   }

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
@@ -47,57 +47,29 @@
 
 {{velocity}}
 #if ($xcontext.action == 'get')
+#set ($selectorUIXs = $services.uix.getExtensions('org.xwiki.contrib.ckeditor.pluginsImageSelector', {'sortByParameter' : 'priority'}))
 {{html clean='false'}}
 &lt;div&gt;
-  &lt;!-- Nav tabs --&gt;
   &lt;ul class="nav nav-tabs" role="tablist"&gt;
-    &lt;li role="presentation" class="active"&gt;
-      &lt;a href="#documentTree" aria-controls="documentTree" role="tab" data-toggle="tab"&gt;
-        $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.documentTreeTab.title'))
-      &lt;/a&gt;
-    &lt;/li&gt;
-    &lt;li role="presentation"&gt;
-      &lt;a href="#upload" aria-controls="upload" role="tab" data-toggle="tab"&gt;
-        $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.title'))
-      &lt;/a&gt;
-    &lt;/li&gt;
+    #set ($firstUIX = true)
+    &lt;!-- Nav tabs --&gt;
+    #foreach ($uix in $selectorUIXs)
+      &lt;li role="presentation" #if($firstUIX)class="active"#end&gt;
+        &lt;a href="#$escapetool.url($uix.parameters.id)"
+          aria-controls="$escapetool.xml($uix.parameters.id)"
+          role="tab" data-toggle="tab"&gt;
+          $escapetool.xml($services.localization.render($uix.parameters.title))
+        &lt;/a&gt;
+      &lt;/li&gt;
+      #set ($firstUIX = false)
+    #end
   &lt;/ul&gt;
 
   &lt;!-- Tab panes --&gt;
   &lt;div class="tab-content"&gt;
-    &lt;div role="tabpanel" class="tab-pane active" id="documentTree"&gt;
-      #template('documentTree_macros.vm')
-      #documentTree({
-        'class': 'attachments-tree',
-        'finder': true,
-        'openTo': "document:$services.model.serialize($doc.documentReference, 'default')",
-        'showWikis': true,
-        'showTranslations': false
-      })
-    &lt;/div&gt;
-    &lt;div role="tabpanel" class="tab-pane" id="upload"&gt;
-      &lt;form class="xform"&gt;
-        &lt;dl&gt;
-          &lt;dt&gt;
-            &lt;label for="fileUploadField"&gt;
-              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.title'))
-            &lt;/label&gt;
-            &lt;span class="xHint"&gt;
-              $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.hint'))
-            &lt;/span&gt;
-          &lt;/dt&gt;
-          &lt;dd&gt;
-            &lt;input id="fileUploadField" name="fileUploadField" type="file" accept="image/*"/&gt;
-          &lt;/dd&gt;
-        &lt;/dl&gt;
-        &lt;p&gt;
-          &lt;span class="buttonwrapper"&gt;
-            &lt;input class="button" type="submit"
-              value="$escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.uploadButton'))"/&gt;
-          &lt;/span&gt;
-        &lt;/p&gt;
-      &lt;/form&gt;
-    &lt;/div&gt;
+    #foreach ($uix in $selectorUIXs)
+      $services.rendering.render($uix.execute(), 'xhtml/1.0')
+    #end
   &lt;/div&gt;
 &lt;/div&gt;
 {{/html}}

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
@@ -67,8 +67,12 @@
 
   &lt;!-- Tab panes --&gt;
   &lt;div class="tab-content"&gt;
+    #set ($firstUIX = true)
     #foreach ($uix in $selectorUIXs)
+      &lt;div role="tabpanel" class="tab-pane#if($firstUIX) active#end" id="$escapetool.url($uix.parameters.id)"&gt;
       $services.rendering.render($uix.execute(), 'xhtml/1.0')
+      &lt;/div&gt;
+      #set ($firstUIX = false)
     #end
   &lt;/div&gt;
 &lt;/div&gt;

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorService.xml
@@ -47,32 +47,29 @@
 
 {{velocity}}
 #if ($xcontext.action == 'get')
-#set ($selectorUIXs = $services.uix.getExtensions('org.xwiki.contrib.ckeditor.pluginsImageSelector', {'sortByParameter' : 'priority'}))
+#set ($selectorUIXs = $services.uix.getExtensions('org.xwiki.contrib.ckeditor.plugins.imageSelector', 
+  {'sortByParameter' : 'priority'}))
 {{html clean='false'}}
 &lt;div&gt;
   &lt;ul class="nav nav-tabs" role="tablist"&gt;
-    #set ($firstUIX = true)
     &lt;!-- Nav tabs --&gt;
     #foreach ($uix in $selectorUIXs)
-      &lt;li role="presentation" #if($firstUIX)class="active"#end&gt;
+      &lt;li role="presentation" #if($foreach.index == 0)class="active"#end&gt;
         &lt;a href="#$escapetool.url($uix.parameters.id)"
           aria-controls="$escapetool.xml($uix.parameters.id)"
           role="tab" data-toggle="tab"&gt;
           $escapetool.xml($services.localization.render($uix.parameters.title))
         &lt;/a&gt;
       &lt;/li&gt;
-      #set ($firstUIX = false)
     #end
   &lt;/ul&gt;
 
   &lt;!-- Tab panes --&gt;
   &lt;div class="tab-content"&gt;
-    #set ($firstUIX = true)
     #foreach ($uix in $selectorUIXs)
-      &lt;div role="tabpanel" class="tab-pane#if($firstUIX) active#end" id="$escapetool.url($uix.parameters.id)"&gt;
+      &lt;div role="tabpanel" class="tab-pane#if($foreach.index == 0) active#end" id="$escapetool.url($uix.parameters.id)"&gt;
       $services.rendering.render($uix.execute(), 'xhtml/1.0')
       &lt;/div&gt;
-      #set ($firstUIX = false)
     #end
   &lt;/div&gt;
 &lt;/div&gt;

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/DocumentTree.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/DocumentTree.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.2" reference="CKEditor.ImageSelectorServiceUIX.DocumentTree" locale="">
+  <web>CKEditor.ImageSelectorServiceUIX</web>
+  <name>DocumentTree</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1650618968000</creationDate>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1650618968000</date>
+  <contentUpdateDate>1650618968000</contentUpdateDate>
+  <version>1.1</version>
+  <title>DocumentTree</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content> </content>
+  <object>
+    <name>CKEditor.ImageSelectorServiceUIX.DocumentTree</name>
+    <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>70c6e90e-95b0-4b0b-a2c8-431df4fe2c21</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>require(['jquery', 'imageSelector'], function($, imageSelector) {
+   function getSelected(instance) {
+      /* jshint camelcase: false */
+      return instance.get_selected(false)[0];
+    }
+  
+  function validateSelection(instance) {
+    var selected = getSelected(instance);
+    return selected &amp;&amp; selected.startsWith("attachment:");
+  }
+
+  $('.attachments-tree').xtree()
+    .one('ready.jstree', function(event, data) {
+      data.instance.openTo("document:" + XWiki.Model.serialize(XWiki.currentDocument.getDocumentReference()));
+    })
+    .on('changed.jstree', function(event, data) {
+      if (validateSelection(data.instance)) {
+        imageSelector.saveSelectedImageReference(getSelected(data.instance));
+      } else {
+         imageSelector.removeSelectedImageReference();
+      }
+    });
+});</code>
+    </property>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <parse>0</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <name>CKEditor.ImageSelectorServiceUIX.DocumentTree</name>
+    <number>0</number>
+    <className>XWiki.UIExtensionClass</className>
+    <guid>fa48e622-1814-4ae5-a64f-f584d3f06d45</guid>
+    <class>
+      <name>XWiki.UIExtensionClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <content>
+        <disabled>0</disabled>
+        <editor>Text</editor>
+        <name>content</name>
+        <number>3</number>
+        <prettyName>Extension Content</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </content>
+      <extensionPointId>
+        <disabled>0</disabled>
+        <name>extensionPointId</name>
+        <number>1</number>
+        <prettyName>Extension Point ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </extensionPointId>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Extension ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parameters>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>parameters</name>
+        <number>4</number>
+        <prettyName>Extension Parameters</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </parameters>
+      <scope>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>scope</name>
+        <number>5</number>
+        <prettyName>Extension Scope</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>wiki=Current Wiki|user=Current User|global=Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </scope>
+    </class>
+    <property>
+      <content>{{velocity}}
+#set ($discard = $xwiki.jsx.use('CKEditor.ImageSelectorServiceUIX.DocumentTree'))
+{{html clean="false"}}
+&lt;div role="tabpanel" class="tab-pane active" id="documentTree"&gt;
+  #template('documentTree_macros.vm')
+  #documentTree({
+    'class': 'attachments-tree',
+    'finder': true,
+    'openTo': "document:$services.model.serialize($doc.documentReference, 'default')",
+    'showWikis': true,
+    'showTranslations': false
+  })
+&lt;/div&gt;
+{{/html}}
+{{/velocity}}</content>
+    </property>
+    <property>
+      <extensionPointId>org.xwiki.contrib.ckeditor.pluginsImageSelector</extensionPointId>
+    </property>
+    <property>
+      <name>org.xwiki.contrib.ckeditor.pluginsImageSelector.documentTree</name>
+    </property>
+    <property>
+      <parameters>priority=100
+title=ckeditor.plugin.image.imageSelector.documentTreeTab.title
+id=documentTree</parameters>
+    </property>
+    <property>
+      <scope>wiki</scope>
+    </property>
+  </object>
+</xwikidoc>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/DocumentTree.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/DocumentTree.xml
@@ -138,9 +138,9 @@
     })
     .on('changed.jstree', function(event, data) {
       if (validateSelection(data.instance)) {
-        imageSelector.saveSelectedImageReference(getSelected(data.instance));
+        imageSelector.updateSelectedImageReferences([getSelected(data.instance)]);
       } else {
-         imageSelector.removeSelectedImageReference();
+         imageSelector.updateSelectedImageReferences([]);
       }
     });
 });</code>
@@ -243,10 +243,10 @@
 {{/velocity}}</content>
     </property>
     <property>
-      <extensionPointId>org.xwiki.contrib.ckeditor.pluginsImageSelector</extensionPointId>
+      <extensionPointId>org.xwiki.contrib.ckeditor.plugins.imageSelector</extensionPointId>
     </property>
     <property>
-      <name>org.xwiki.contrib.ckeditor.pluginsImageSelector.documentTree</name>
+      <name>org.xwiki.contrib.ckeditor.plugins.imageSelector.documentTree</name>
     </property>
     <property>
       <parameters>priority=200

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/DocumentTree.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/DocumentTree.xml
@@ -231,7 +231,6 @@
       <content>{{velocity}}
 #set ($discard = $xwiki.jsx.use('CKEditor.ImageSelectorServiceUIX.DocumentTree'))
 {{html clean="false"}}
-&lt;div role="tabpanel" class="tab-pane active" id="documentTree"&gt;
   #template('documentTree_macros.vm')
   #documentTree({
     'class': 'attachments-tree',
@@ -240,7 +239,6 @@
     'showWikis': true,
     'showTranslations': false
   })
-&lt;/div&gt;
 {{/html}}
 {{/velocity}}</content>
     </property>
@@ -251,7 +249,7 @@
       <name>org.xwiki.contrib.ckeditor.pluginsImageSelector.documentTree</name>
     </property>
     <property>
-      <parameters>priority=100
+      <parameters>priority=200
 title=ckeditor.plugin.image.imageSelector.documentTreeTab.title
 id=documentTree</parameters>
     </property>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/Upload.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/Upload.xml
@@ -122,35 +122,25 @@
     </property>
     <property>
       <code>require(['jquery', 'imageSelector', 'l10n!imageSelector', 'resource'], function($, imageSelector, translations, resource) {
-  var editor = imageSelector.getEditor();
   $("#upload form input.button").on('click', function(event) {
     event.preventDefault();
-    var loader = editor.uploadRepository.create($("#fileUploadField").prop('files')[0]);
     var imageSelectorElement = $('.image-selector');
-    loader.on('uploaded', function(evt) {
-      var resourceReference = evt.sender.responseData.message.resourceReference;
-      var entityReference = resource.convertResourceReferenceToEntityReference(resourceReference);
-      var serialized = XWiki.Model.serialize(entityReference);
-      imageSelector.saveSelectedImageReference(serialized);
-      imageSelectorElement.removeClass('loading');
-      new XWiki.widgets.Notification(translations.get('modal.fileUpload.success'), 'done');
-    });
-
-    // Return non-false value will disable fileButton in dialogui,
-    // below listeners takes care of such situation and re-enable "send" button.
-    loader.on('error', function(error) {
-      console.log('Failed to upload a file', error);
-      new XWiki.widgets.Notification(translations.get('modal.fileUpload.fail'), 'error');
-      imageSelectorElement.removeClass('loading');
-    });
-    loader.on('abort', function(error) {
-      console.log('Failed to upload a file', error);
-      new XWiki.widgets.Notification(translations.get('modal.fileUpload.abort'), 'error');
-      imageSelectorElement.removeClass('loading');
-    });
-
     imageSelectorElement.addClass('loading');
-    loader.loadAndUpload(editor.config.filebrowserUploadUrl);
+    imageSelector.createLoader($("#fileUploadField").prop('files')[0], {
+      onSuccess: function(entityReference) {
+        imageSelector.updateSelectedImageReferences([XWiki.Model.serialize(entityReference)]);
+        imageSelectorElement.removeClass('loading');
+        new XWiki.widgets.Notification(translations.get('modal.fileUpload.success'), 'done');
+      },
+      onError: function() {
+        new XWiki.widgets.Notification(translations.get('modal.fileUpload.fail'), 'error');
+        imageSelectorElement.removeClass('loading');
+      },
+      onAbort: function() {
+        new XWiki.widgets.Notification(translations.get('modal.fileUpload.abort'), 'error');
+        imageSelectorElement.removeClass('loading');
+      }
+    });
   });
 });
 </code>
@@ -266,10 +256,10 @@
 {{/velocity}}</content>
     </property>
     <property>
-      <extensionPointId>org.xwiki.contrib.ckeditor.pluginsImageSelector</extensionPointId>
+      <extensionPointId>org.xwiki.contrib.ckeditor.plugins.imageSelector</extensionPointId>
     </property>
     <property>
-      <name>org.xwiki.contrib.ckeditor.pluginsImageSelector.upload</name>
+      <name>org.xwiki.contrib.ckeditor.plugins.imageSelector.upload</name>
     </property>
     <property>
       <parameters>priority=300

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/Upload.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/Upload.xml
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.2" reference="CKEditor.ImageSelectorServiceUIX.Upload" locale="">
+  <web>CKEditor.ImageSelectorServiceUIX</web>
+  <name>Upload</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1650619118000</creationDate>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1650619118000</date>
+  <contentUpdateDate>1650619118000</contentUpdateDate>
+  <version>1.1</version>
+  <title>Upload</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content> </content>
+  <object>
+    <name>CKEditor.ImageSelectorServiceUIX.Upload</name>
+    <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>fa0daa47-0586-4a9a-be22-16da6c5d8aa4</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>require(['jquery', 'imageSelector', 'l10n!imageSelector', 'resource'], function($, imageSelector, translations, resource) {
+  var editor = imageSelector.getEditor();
+  $("#upload form input.button").on('click', function(event) {
+    event.preventDefault();
+    var loader = editor.uploadRepository.create($("#fileUploadField").prop('files')[0]);
+    var imageSelectorElement = $('.image-selector');
+    loader.on('uploaded', function(evt) {
+      var resourceReference = evt.sender.responseData.message.resourceReference;
+      var entityReference = resource.convertResourceReferenceToEntityReference(resourceReference);
+      var serialized = XWiki.Model.serialize(entityReference);
+      imageSelector.saveSelectedImageReference(serialized);
+      imageSelectorElement.removeClass('loading');
+      new XWiki.widgets.Notification(translations.get('modal.fileUpload.success'), 'done');
+    });
+
+    // Return non-false value will disable fileButton in dialogui,
+    // below listeners takes care of such situation and re-enable "send" button.
+    loader.on('error', function(error) {
+      console.log('Failed to upload a file', error);
+      new XWiki.widgets.Notification(translations.get('modal.fileUpload.fail'), 'error');
+      imageSelectorElement.removeClass('loading');
+    });
+    loader.on('abort', function(error) {
+      console.log('Failed to upload a file', error);
+      new XWiki.widgets.Notification(translations.get('modal.fileUpload.abort'), 'error');
+      imageSelectorElement.removeClass('loading');
+    });
+
+    imageSelectorElement.addClass('loading');
+    loader.loadAndUpload(editor.config.filebrowserUploadUrl);
+  });
+});
+</code>
+    </property>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <parse>0</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <name>CKEditor.ImageSelectorServiceUIX.Upload</name>
+    <number>0</number>
+    <className>XWiki.UIExtensionClass</className>
+    <guid>eacdf8f2-4f11-473b-88d6-006b39cd54f3</guid>
+    <class>
+      <name>XWiki.UIExtensionClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <content>
+        <disabled>0</disabled>
+        <editor>Text</editor>
+        <name>content</name>
+        <number>3</number>
+        <prettyName>Extension Content</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </content>
+      <extensionPointId>
+        <disabled>0</disabled>
+        <name>extensionPointId</name>
+        <number>1</number>
+        <prettyName>Extension Point ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </extensionPointId>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Extension ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parameters>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>parameters</name>
+        <number>4</number>
+        <prettyName>Extension Parameters</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </parameters>
+      <scope>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>scope</name>
+        <number>5</number>
+        <prettyName>Extension Scope</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>wiki=Current Wiki|user=Current User|global=Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </scope>
+    </class>
+    <property>
+      <content>{{velocity}}
+#set ($discard = $xwiki.jsx.use('CKEditor.ImageSelectorServiceUIX.Upload'))
+{{html clean="false"}}
+&lt;div role="tabpanel" class="tab-pane" id="upload"&gt;
+  &lt;form class="xform"&gt;
+    &lt;dl&gt;
+      &lt;dt&gt;
+        &lt;label for="fileUploadField"&gt;
+          $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.title'))
+        &lt;/label&gt;
+        &lt;span class="xHint"&gt;
+          $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.hint'))
+        &lt;/span&gt;
+      &lt;/dt&gt;
+      &lt;dd&gt;
+        &lt;input id="fileUploadField" name="fileUploadField" type="file" accept="image/*"/&gt;
+      &lt;/dd&gt;
+    &lt;/dl&gt;
+    &lt;p&gt;
+      &lt;span class="buttonwrapper"&gt;
+        &lt;input class="button" type="submit"
+          value="$escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.uploadButton'))"/&gt;
+      &lt;/span&gt;
+    &lt;/p&gt;
+  &lt;/form&gt;
+&lt;/div&gt;
+{{/html}}
+{{/velocity}}</content>
+    </property>
+    <property>
+      <extensionPointId>org.xwiki.contrib.ckeditor.pluginsImageSelector</extensionPointId>
+    </property>
+    <property>
+      <name>org.xwiki.contrib.ckeditor.pluginsImageSelector.upload</name>
+    </property>
+    <property>
+      <parameters>priority=200
+title=ckeditor.plugin.image.imageSelector.uploadTab.title
+id=upload</parameters>
+    </property>
+    <property>
+      <scope>wiki</scope>
+    </property>
+  </object>
+</xwikidoc>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/Upload.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/Upload.xml
@@ -241,29 +241,27 @@
       <content>{{velocity}}
 #set ($discard = $xwiki.jsx.use('CKEditor.ImageSelectorServiceUIX.Upload'))
 {{html clean="false"}}
-&lt;div role="tabpanel" class="tab-pane" id="upload"&gt;
-  &lt;form class="xform"&gt;
-    &lt;dl&gt;
-      &lt;dt&gt;
-        &lt;label for="fileUploadField"&gt;
-          $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.title'))
-        &lt;/label&gt;
-        &lt;span class="xHint"&gt;
-          $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.hint'))
-        &lt;/span&gt;
-      &lt;/dt&gt;
-      &lt;dd&gt;
-        &lt;input id="fileUploadField" name="fileUploadField" type="file" accept="image/*"/&gt;
-      &lt;/dd&gt;
-    &lt;/dl&gt;
-    &lt;p&gt;
-      &lt;span class="buttonwrapper"&gt;
-        &lt;input class="button" type="submit"
-          value="$escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.uploadButton'))"/&gt;
+&lt;form class="xform"&gt;
+  &lt;dl&gt;
+    &lt;dt&gt;
+      &lt;label for="fileUploadField"&gt;
+        $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.title'))
+      &lt;/label&gt;
+      &lt;span class="xHint"&gt;
+        $escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.file.hint'))
       &lt;/span&gt;
-    &lt;/p&gt;
-  &lt;/form&gt;
-&lt;/div&gt;
+    &lt;/dt&gt;
+    &lt;dd&gt;
+      &lt;input id="fileUploadField" name="fileUploadField" type="file" accept="image/*"/&gt;
+    &lt;/dd&gt;
+  &lt;/dl&gt;
+  &lt;p&gt;
+    &lt;span class="buttonwrapper"&gt;
+      &lt;input class="button" type="submit"
+        value="$escapetool.xml($services.localization.render('ckeditor.plugin.image.imageSelector.uploadTab.uploadButton'))"/&gt;
+    &lt;/span&gt;
+  &lt;/p&gt;
+&lt;/form&gt;
 {{/html}}
 {{/velocity}}</content>
     </property>
@@ -274,7 +272,7 @@
       <name>org.xwiki.contrib.ckeditor.pluginsImageSelector.upload</name>
     </property>
     <property>
-      <parameters>priority=200
+      <parameters>priority=300
 title=ckeditor.plugin.image.imageSelector.uploadTab.title
 id=upload</parameters>
     </property>

--- a/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/WebHome.xml
+++ b/application-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/WebHome.xml
@@ -1,4 +1,5 @@
-/*
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
  *
@@ -16,37 +17,27 @@
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
- */
+-->
 
-define('imageWizard', ['imageSelector', 'imageEditor'], function(imageSelector, imageEditor) {
-  'use strict';
-
-  function backToSelectionOrFinish(data) {
-    if (data.action === 'selectImage') {
-      return selectAndEdit(data);
-    } else {
-      return data;
-    }
-  }
-
-  function editOnly(params) {
-    return imageEditor(params)
-      .then(backToSelectionOrFinish);
-  }
-
-  function selectAndEdit(params) {
-    params = params || {};
-    params.newImage = true;
-    return imageSelector.createModal(params)
-      .then(imageEditor)
-      .then(backToSelectionOrFinish);
-  }
-
-  return function(params) {
-    if (params.imageData && params.imageData.resourceReference) {
-      return editOnly(params);
-    } else {
-      return selectAndEdit(params);
-    }
-  };
-});
+<xwikidoc version="1.5" reference="CKEditor.ImageSelectorServiceUIX.WebHome" locale="">
+  <web>CKEditor.ImageSelectorServiceUIX</web>
+  <name>WebHome</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1650619491000</creationDate>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <originalMetadataAuthor>XWiki.Admin</originalMetadataAuthor>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1650619491000</date>
+  <contentUpdateDate>1650619491000</contentUpdateDate>
+  <version>1.1</version>
+  <title>ImageSelectorServiceUIX</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content> </content>
+</xwikidoc>


### PR DESCRIPTION
- Introduce the org.xwiki.contrib.ckeditor.pluginsImageSelector UIXP
- Use the UIXP to display the tabs and tabs content in the image selector modal
- Move the document tree and upload tabs in dedicated UIXs
- Expose operations required by the UIXs javascript code in imageSelector
- The javascript specific to each tab is moved to jsx objects in respective UIXs documents


See https://jira.xwiki.org/browse/CKEDITOR-437