### PR TITLE
CKEDITOR-500: Editing a macro that has a picker allowing multiple options merges the selected options instead of displaying them separately.

### DIFF
--- a/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
@@ -530,7 +530,7 @@ define('macroParameterTreeDisplayer', ['jquery', 'l10n!macroEditor'], function($
       valueInputs = valueInputs.first();
       // For select inputs we should add the value to the list of options if it's missing.
       if (value && valueInputs.is('select')) {
-        value = value.split(',');
+        value = valueInputs.prop('type') === 'select-multiple' ? value.split(',') : [value];
         value.forEach(function (val, index) {
           var matchedOption = valueInputs.find('option').filter(matchesParameterValue(val));
           if (matchedOption.length > 0) {
@@ -538,7 +538,7 @@ define('macroParameterTreeDisplayer', ['jquery', 'l10n!macroEditor'], function($
             value[index] = matchedOption.val();
           } else {
             // Add the missing option.
-            $('<option></option>').val(value[index]).text(value[index]).appendTo(valueInputs);
+            $('<option></option>').val(val).text(val).appendTo(valueInputs);
           }
         });
       }

--- a/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
@@ -507,11 +507,13 @@ define('macroParameterTreeDisplayer', ['jquery', 'l10n!macroEditor'], function($
     });
     var firstInputType = valueInputs.prop('type');
     var value = parameter.hasOwnProperty('value') ? parameter.value : parameter.defaultValue;
-    var matchesParameterValue = function() {
-      if (parameter.caseInsensitive) {
-        return $(this).val().toUpperCase() === value.toUpperCase();
-      } else {
-        return $(this).val() === value;
+    var matchesParameterValue = function(value) {
+      return function() {
+        if (parameter.caseInsensitive) {
+          return $(this).val().toUpperCase() === value.toUpperCase();
+        } else {
+          return $(this).val() === value;
+        }
       }
     };
     if (firstInputType === 'checkbox' || firstInputType === 'radio') {
@@ -521,30 +523,28 @@ define('macroParameterTreeDisplayer', ['jquery', 'l10n!macroEditor'], function($
       });
       if (parameter.caseInsensitive) {
         // Use the canonical value.
-        value = valueInputs.filter(matchesParameterValue).val() || value;
+        value = valueInputs.filter(matchesParameterValue(value)).val() || value;
       }
     } else {
       // Keep only the first input element.
       valueInputs = valueInputs.first();
       // For select inputs we should add the value to the list of options if it's missing.
       if (value && valueInputs.is('select')) {
-        var matchedOption = valueInputs.find('option').filter(matchesParameterValue);
-        if (matchedOption.length > 0) {
-          // Use the canonical value.
-          value = matchedOption.val();
-        } else if ('select-multiple' === firstInputType) {
-          // Add the missing options if the select allows multiple values.
-          value.split(',').forEach(function (entry) {
-            $('<option></option>').val(entry).text(entry).appendTo(valueInputs);
-          });
-        } else {
-          // Add the missing option.
-          $('<option></option>').val(value).text(value).appendTo(valueInputs);
-        }
+        value = value.split(',');
+        value.forEach(function (val, index) {
+          var matchedOption = valueInputs.find('option').filter(matchesParameterValue(val));
+          if (matchedOption.length > 0) {
+            // Use the canonical value.
+            value[index] = matchedOption.val();
+          } else {
+            // Add the missing option.
+            $('<option></option>').val(value[index]).text(value[index]).appendTo(valueInputs);
+          }
+        });
       }
     }
     // We pass the value as an array in order to properly handle radio inputs and checkboxes.
-    valueInputs.val(value && 'select-multiple' === firstInputType ? value.split(',') : [value]);
+    valueInputs.val(Array.isArray(value) ? value : [value]);
     return field;
   },
 

--- a/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
+++ b/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js
@@ -532,6 +532,11 @@ define('macroParameterTreeDisplayer', ['jquery', 'l10n!macroEditor'], function($
         if (matchedOption.length > 0) {
           // Use the canonical value.
           value = matchedOption.val();
+        } else if ('select-multiple' === firstInputType) {
+          // Add the missing options if the select allows multiple values.
+          value.split(',').forEach(function (entry) {
+            $('<option></option>').val(entry).text(entry).appendTo(valueInputs);
+          });
         } else {
           // Add the missing option.
           $('<option></option>').val(value).text(value).appendTo(valueInputs);
@@ -539,7 +544,7 @@ define('macroParameterTreeDisplayer', ['jquery', 'l10n!macroEditor'], function($
       }
     }
     // We pass the value as an array in order to properly handle radio inputs and checkboxes.
-    valueInputs.val([value]);
+    valueInputs.val(value && 'select-multiple' === firstInputType ? value.split(',') : [value]);
     return field;
   },
 


### PR DESCRIPTION
PR for the issue: https://jira.xwiki.org/browse/CKEDITOR-500 .

When the parameter supports multiple values, they are joined together in a string at https://github.com/xwiki-contrib/application-ckeditor/blob/master/application-ckeditor-plugins/src/main/resources/xwiki-macro/macroEditor.js#L654 , but this case was never handled when the parameter is displayed. Thus, the values were displayed as merged together. 
